### PR TITLE
Persist DB when SIGTERM received

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,29 @@ docker pull taymour/elysiandb:latest
 docker pull taymour/elysiandb:0.1.2
 ```
 
+## Persistence & Shutdown Behavior
+
+ElysianDB persists in‑memory data to disk in the following cases:
+
+1. **Periodic flush** — Controlled by `store.flushIntervalSeconds` (see **Configuration**). Data is snapshotted to disk at the configured interval.
+2. **Manual save** —
+
+   * **HTTP**: `POST /save`
+   * **TCP**: `SAVE`
+     Forces an immediate snapshot to disk.
+3. **Graceful shutdown** — On **SIGTERM** or **SIGINT** (e.g., `docker stop`, Ctrl+C), ElysianDB flushes current data to disk before exiting and logs a shutdown message.
+
+> **Note:** **SIGKILL (9)** cannot be intercepted on Unix-like systems; if the process is killed with SIGKILL, no shutdown hook runs and a final flush cannot be guaranteed.
+
+### Quick verification
+
+```bash
+# Run locally and write some data, then trigger a graceful stop:
+kill -TERM <elysiandb_pid>
+# or Ctrl+C in the foreground process
+# After restart, verify your data is present.
+```
+
 ### Quick start (ephemeral)
 
 ```bash

--- a/elysiandb.go
+++ b/elysiandb.go
@@ -1,12 +1,17 @@
 package main
 
 import (
+	"context"
 	"fmt"
+	"os"
+	"os/signal"
+	"syscall"
 
 	"github.com/taymour/elysiandb/internal/boot"
 	"github.com/taymour/elysiandb/internal/configuration"
 	"github.com/taymour/elysiandb/internal/globals"
 	"github.com/taymour/elysiandb/internal/log"
+	"github.com/taymour/elysiandb/internal/storage"
 )
 
 func main() {
@@ -41,6 +46,14 @@ func main() {
 		go boot.InitTCP()
 	}
 
-	// Block forever
-	select {}
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
+	<-ctx.Done()
+
+	storage.WriteToDB()
+
+	log.DirectInfo("Data persisted successfully.")
+
+	log.DirectInfo("ElysianDB shutting down gracefully. Goodbye!")
 }


### PR DESCRIPTION
# Persist DB when SIGTERM received

## Summary

This PR ensures that ElysianDB persists in‑memory data to disk when the process receives a graceful termination signal (SIGTERM) and then exits cleanly. This improves durability during orchestrated shutdowns (e.g., `docker stop`, systemd) without changing runtime behavior during normal operation.

## Changes

* Add signal handling for `SIGTERM` (and `SIGINT` for Ctrl+C) using `signal.NotifyContext`.
* On signal reception, trigger `storage.WriteToDB()` before process exit.
* Log successful persistence and a final shutdown message.
* Replace the infinite `select {}` with `<-ctx.Done()` to block until a signal is received.
* 
## Notes

* `SIGKILL` (9) is not catchable; no persistence is possible in that case.
* This PR does not change persistence cadence during normal runtime—only at graceful shutdown.

## Backward compatibility

Backward‑compatible. No config changes required. Behavior only differs during graceful shutdown.
