### PR TITLE
Added optional runtime statistics and /stats endpoint

### DIFF
--- a/elysian.yaml
+++ b/elysian.yaml
@@ -7,3 +7,5 @@ server:
   tcp:  { enabled: true,  host: 0.0.0.0, port: 8088 }
 log:
   flushIntervalSeconds: 5
+stats:
+  enabled: false

--- a/elysiandb.go
+++ b/elysiandb.go
@@ -34,6 +34,10 @@ func main() {
 
 	log.DirectInfo("Using data folder: ", globals.GetConfig().Store.Folder)
 
+	if cfg.Stats.Enabled {
+		boot.BootStats()
+	}
+
 	boot.InitDB()
 
 	log.DirectInfo("Ready to serve your key-value needs with elegance.")

--- a/internal/boot/stat.go
+++ b/internal/boot/stat.go
@@ -1,0 +1,19 @@
+package boot
+
+import (
+	"time"
+
+	"github.com/taymour/elysiandb/internal/stat"
+)
+
+func BootStats() {
+	stat.Init()
+	go collect()
+}
+
+func collect() {
+	for {
+		stat.Stats.IncrementUptimeSeconds()
+		time.Sleep(1 * time.Second)
+	}
+}

--- a/internal/configuration/loader.go
+++ b/internal/configuration/loader.go
@@ -12,6 +12,7 @@ type Config struct {
 	Store  StoreConfig   `yaml:"store"`
 	Server ServersConfig `yaml:"server"`
 	Log    LogConfig     `yaml:"log"`
+	Stats  StatsConfig   `yaml:"stats"`
 }
 
 type ServersConfig struct {
@@ -33,6 +34,10 @@ type StoreConfig struct {
 	Folder               string `yaml:"folder"`
 	Shards               int    `yaml:"shards"`
 	FlushIntervalSeconds int    `yaml:"flushIntervalSeconds"`
+}
+
+type StatsConfig struct {
+	Enabled bool `yaml:"enabled"`
 }
 
 func LoadConfig(path string) (*Config, error) {

--- a/internal/routing/router.go
+++ b/internal/routing/router.go
@@ -2,6 +2,7 @@ package routing
 
 import (
 	"github.com/fasthttp/router"
+	"github.com/taymour/elysiandb/internal/globals"
 	"github.com/taymour/elysiandb/internal/transport/http/controller"
 )
 
@@ -16,4 +17,8 @@ func RegisterRoutes(r *router.Router) {
 	r.POST("/save", controller.SaveController)
 
 	r.POST("/reset", controller.ResetController)
+
+	if globals.GetConfig().Stats.Enabled {
+		r.GET("/stats", controller.StatsController)
+	}
 }

--- a/internal/stat/stat.go
+++ b/internal/stat/stat.go
@@ -1,0 +1,9 @@
+package stat
+
+var (
+	Stats StatsContainer
+)
+
+func Init() {
+	Stats = *NewStatsContainer()
+}

--- a/internal/stat/types.go
+++ b/internal/stat/types.go
@@ -1,0 +1,83 @@
+package stat
+
+import (
+	"encoding/json"
+	"sync/atomic"
+)
+
+type StatsContainer struct {
+	keysCount           atomic.Uint64
+	expirationKeysCount atomic.Uint64
+	uptimeSeconds       atomic.Uint64
+	totalRequests       atomic.Uint64
+	hits                atomic.Uint64
+	misses              atomic.Uint64
+}
+
+func NewStatsContainer() *StatsContainer {
+	return &StatsContainer{}
+}
+
+func (s *StatsContainer) IncrementKeysCount()                 { s.keysCount.Add(1) }
+func (s *StatsContainer) IncrementExpirationKeysCount()       { s.expirationKeysCount.Add(1) }
+func (s *StatsContainer) IncrementTotalRequests()             { s.totalRequests.Add(1) }
+func (s *StatsContainer) IncrementUptimeSeconds()             { s.uptimeSeconds.Add(1) }
+func (s *StatsContainer) IncrementHits()                      { s.hits.Add(1) }
+func (s *StatsContainer) IncrementMisses()                    { s.misses.Add(1) }
+func (s *StatsContainer) SetKeysCount(count uint64)           { s.keysCount.Store(count) }
+func (s *StatsContainer) SetExpirationKeysCount(count uint64) { s.expirationKeysCount.Store(count) }
+
+func (s *StatsContainer) DecrementKeysCount() {
+	for {
+		v := s.keysCount.Load()
+		if v == 0 {
+			return
+		}
+		if s.keysCount.CompareAndSwap(v, v-1) {
+			return
+		}
+	}
+}
+
+func (s *StatsContainer) DecrementExpirationKeysCount() {
+	for {
+		v := s.expirationKeysCount.Load()
+		if v == 0 {
+			return
+		}
+		if s.expirationKeysCount.CompareAndSwap(v, v-1) {
+			return
+		}
+	}
+}
+
+func (s *StatsContainer) Reset() {
+	s.keysCount.Store(0)
+	s.expirationKeysCount.Store(0)
+	s.uptimeSeconds.Store(0)
+	s.totalRequests.Store(0)
+	s.hits.Store(0)
+	s.misses.Store(0)
+}
+
+type statsDTO struct {
+	KeysCount           uint64 `json:"keys_count,string"`
+	ExpirationKeysCount uint64 `json:"expiration_keys_count,string"`
+	UptimeSeconds       uint64 `json:"uptime_seconds,string"`
+	TotalRequests       uint64 `json:"total_requests,string"`
+	Hits                uint64 `json:"hits,string"`
+	Misses              uint64 `json:"misses,string"`
+}
+
+func (s *StatsContainer) ToJson() string {
+	dto := statsDTO{
+		KeysCount:           s.keysCount.Load(),
+		ExpirationKeysCount: s.expirationKeysCount.Load(),
+		UptimeSeconds:       s.uptimeSeconds.Load(),
+		TotalRequests:       s.totalRequests.Load(),
+		Hits:                s.hits.Load(),
+		Misses:              s.misses.Load(),
+	}
+	b, _ := json.Marshal(dto)
+	return string(b)
+}

--- a/internal/storage/store.go
+++ b/internal/storage/store.go
@@ -36,6 +36,19 @@ func newExpirationContainer() *ExpirationContainer {
 	return c
 }
 
+func (s *ExpirationContainer) CountTotalKeys() uint64 {
+	total := uint64(0)
+	s.mu.RLock()
+	for _, b := range s.Buckets {
+		b.mu.RLock()
+		total += uint64(len(b.Keys))
+		b.mu.RUnlock()
+	}
+
+	s.mu.RUnlock()
+	return total
+}
+
 func (c *ExpirationContainer) put(ts int64, keys []string) {
 	for _, k := range keys {
 		c.del(k)
@@ -156,6 +169,18 @@ func NewStore() *Store {
 	s.saved.Store(true)
 
 	return s
+}
+
+func (s *Store) CountTotalKeys() uint64 {
+	total := uint64(0)
+	for i := 0; i < s.shardCount; i++ {
+		sh := s.shards[i]
+		sh.mu.RLock()
+		total += uint64(len(sh.m))
+		sh.mu.RUnlock()
+	}
+
+	return total
 }
 
 func (s *Store) reset() {

--- a/internal/transport/http/controller/delete_key.go
+++ b/internal/transport/http/controller/delete_key.go
@@ -3,11 +3,17 @@ package controller
 import (
 	"net/http"
 
+	"github.com/taymour/elysiandb/internal/globals"
+	"github.com/taymour/elysiandb/internal/stat"
 	"github.com/taymour/elysiandb/internal/storage"
 	"github.com/valyala/fasthttp"
 )
 
 func DeleteKeyController(ctx *fasthttp.RequestCtx) {
+	if globals.GetConfig().Stats.Enabled {
+		stat.Stats.IncrementTotalRequests()
+	}
+
 	key := ctx.UserValue("key").(string)
 	storage.DeleteByKey(key)
 	ctx.SetStatusCode(http.StatusNoContent)

--- a/internal/transport/http/controller/get_key.go
+++ b/internal/transport/http/controller/get_key.go
@@ -4,25 +4,45 @@ import (
 	"fmt"
 	"net/http"
 
+	"github.com/taymour/elysiandb/internal/globals"
+	"github.com/taymour/elysiandb/internal/stat"
 	"github.com/taymour/elysiandb/internal/storage"
 	"github.com/valyala/fasthttp"
 )
 
 func GetKeyController(ctx *fasthttp.RequestCtx) {
+	cfg := globals.GetConfig()
+	if cfg.Stats.Enabled {
+		stat.Stats.IncrementTotalRequests()
+	}
+
 	ctx.SetContentType("text/plain; charset=utf-8")
 
 	key := ctx.UserValue("key").(string)
 
 	if storage.KeyHasExpired(key) {
 		storage.DeleteByKey(key)
+
+		if cfg.Stats.Enabled {
+			stat.Stats.IncrementMisses()
+		}
+
 		ctx.Error(fmt.Errorf("key '%s' not found", key).Error(), http.StatusNotFound)
 		return
 	}
 
 	data, err := storage.GetByKey(key)
 	if err != nil {
+		if cfg.Stats.Enabled {
+			stat.Stats.IncrementMisses()
+		}
+
 		ctx.Error(fmt.Errorf("key '%s' not found", key).Error(), http.StatusNotFound)
 		return
+	}
+
+	if cfg.Stats.Enabled {
+		stat.Stats.IncrementHits()
 	}
 
 	_, _ = ctx.Write(data)

--- a/internal/transport/http/controller/put_key.go
+++ b/internal/transport/http/controller/put_key.go
@@ -3,11 +3,17 @@ package controller
 import (
 	"net/http"
 
+	"github.com/taymour/elysiandb/internal/globals"
+	"github.com/taymour/elysiandb/internal/stat"
 	"github.com/taymour/elysiandb/internal/storage"
 	"github.com/valyala/fasthttp"
 )
 
 func PutKeyController(ctx *fasthttp.RequestCtx) {
+	if globals.GetConfig().Stats.Enabled {
+		stat.Stats.IncrementTotalRequests()
+	}
+
 	key := ctx.UserValue("key").(string)
 	ttl := ctx.QueryArgs().GetUintOrZero("ttl")
 

--- a/internal/transport/http/controller/reset.go
+++ b/internal/transport/http/controller/reset.go
@@ -3,11 +3,17 @@ package controller
 import (
 	"net/http"
 
+	"github.com/taymour/elysiandb/internal/globals"
+	"github.com/taymour/elysiandb/internal/stat"
 	"github.com/taymour/elysiandb/internal/storage"
 	"github.com/valyala/fasthttp"
 )
 
 func ResetController(ctx *fasthttp.RequestCtx) {
+	if globals.GetConfig().Stats.Enabled {
+		stat.Stats.IncrementTotalRequests()
+	}
+
 	ctx.SetContentType("application/json")
 	ctx.SetStatusCode(http.StatusOK)
 

--- a/internal/transport/http/controller/save.go
+++ b/internal/transport/http/controller/save.go
@@ -3,11 +3,17 @@ package controller
 import (
 	"net/http"
 
+	"github.com/taymour/elysiandb/internal/globals"
+	"github.com/taymour/elysiandb/internal/stat"
 	"github.com/taymour/elysiandb/internal/storage"
 	"github.com/valyala/fasthttp"
 )
 
 func SaveController(ctx *fasthttp.RequestCtx) {
+	if globals.GetConfig().Stats.Enabled {
+		stat.Stats.IncrementTotalRequests()
+	}
+
 	ctx.SetContentType("application/json")
 	ctx.SetStatusCode(http.StatusNoContent)
 

--- a/internal/transport/http/controller/stats.go
+++ b/internal/transport/http/controller/stats.go
@@ -1,0 +1,11 @@
+package controller
+
+import (
+	"github.com/taymour/elysiandb/internal/stat"
+	"github.com/valyala/fasthttp"
+)
+
+func StatsController(ctx *fasthttp.RequestCtx) {
+	ctx.SetContentType("application/json")
+	_, _ = ctx.Write([]byte(stat.Stats.ToJson()))
+}

--- a/internal/transport/tcp/handler/delete_key.go
+++ b/internal/transport/tcp/handler/delete_key.go
@@ -1,8 +1,16 @@
 package handler
 
-import "github.com/taymour/elysiandb/internal/storage"
+import (
+	"github.com/taymour/elysiandb/internal/globals"
+	"github.com/taymour/elysiandb/internal/stat"
+	"github.com/taymour/elysiandb/internal/storage"
+)
 
 func HandleDelete(query []byte) []byte {
+	if globals.GetConfig().Stats.Enabled {
+		stat.Stats.IncrementTotalRequests()
+	}
+
 	storage.DeleteByKey(string(query))
 	return []byte("OK")
 }

--- a/internal/transport/tcp/handler/get_key.go
+++ b/internal/transport/tcp/handler/get_key.go
@@ -1,18 +1,40 @@
 package handler
 
-import "github.com/taymour/elysiandb/internal/storage"
+import (
+	"github.com/taymour/elysiandb/internal/globals"
+	"github.com/taymour/elysiandb/internal/stat"
+	"github.com/taymour/elysiandb/internal/storage"
+)
 
 func HandleGet(query []byte) []byte {
+	cfg := globals.GetConfig()
+	if cfg.Stats.Enabled {
+		stat.Stats.IncrementTotalRequests()
+	}
+
 	key := string(query)
 
 	if storage.KeyHasExpired(key) {
 		storage.DeleteByKey(key)
+
+		if cfg.Stats.Enabled {
+			stat.Stats.IncrementMisses()
+		}
+
 		return []byte("Key not found")
 	}
 
 	data, err := storage.GetByKey(key)
 	if err != nil {
+		if cfg.Stats.Enabled {
+			stat.Stats.IncrementMisses()
+		}
+
 		return []byte("Key not found")
+	}
+
+	if cfg.Stats.Enabled {
+		stat.Stats.IncrementHits()
 	}
 
 	return data

--- a/internal/transport/tcp/handler/multi_get.go
+++ b/internal/transport/tcp/handler/multi_get.go
@@ -3,11 +3,18 @@ package handler
 import (
 	"strings"
 
+	"github.com/taymour/elysiandb/internal/globals"
+	"github.com/taymour/elysiandb/internal/stat"
 	"github.com/taymour/elysiandb/internal/storage"
 	"github.com/taymour/elysiandb/internal/transport/tcp/parsing"
 )
 
 func HandleMultiGet(query []byte) []byte {
+	cfg := globals.GetConfig()
+	if cfg.Stats.Enabled {
+		stat.Stats.IncrementTotalRequests()
+	}
+
 	keys := strings.Split(string(query), " ")
 	if len(keys) == 0 {
 		return []byte("ERR")
@@ -17,17 +24,30 @@ func HandleMultiGet(query []byte) []byte {
 	for i, key := range keys {
 		if storage.KeyHasExpired(key) {
 			storage.DeleteByKey(key)
+
+			if cfg.Stats.Enabled {
+				stat.Stats.IncrementMisses()
+			}
+
 			results[i] = []byte("Key not found")
 			continue
 		}
 
 		data, err := storage.GetByKey(key)
 		if err != nil {
+			if cfg.Stats.Enabled {
+				stat.Stats.IncrementMisses()
+			}
+
 			results[i] = []byte("Key not found")
 			continue
 		}
 
 		results[i] = data
+
+		if cfg.Stats.Enabled {
+			stat.Stats.IncrementHits()
+		}
 	}
 
 	return parsing.JoinByteSlices(results, []byte("\n"))

--- a/internal/transport/tcp/handler/reset.go
+++ b/internal/transport/tcp/handler/reset.go
@@ -1,8 +1,16 @@
 package handler
 
-import "github.com/taymour/elysiandb/internal/storage"
+import (
+	"github.com/taymour/elysiandb/internal/globals"
+	"github.com/taymour/elysiandb/internal/stat"
+	"github.com/taymour/elysiandb/internal/storage"
+)
 
 func HandleReset() []byte {
+	if globals.GetConfig().Stats.Enabled {
+		stat.Stats.IncrementTotalRequests()
+	}
+
 	storage.ResetStore()
 	return []byte("OK")
 }

--- a/internal/transport/tcp/handler/save.go
+++ b/internal/transport/tcp/handler/save.go
@@ -1,8 +1,16 @@
 package handler
 
-import "github.com/taymour/elysiandb/internal/storage"
+import (
+	"github.com/taymour/elysiandb/internal/globals"
+	"github.com/taymour/elysiandb/internal/stat"
+	"github.com/taymour/elysiandb/internal/storage"
+)
 
 func HandleSave() []byte {
+	if globals.GetConfig().Stats.Enabled {
+		stat.Stats.IncrementTotalRequests()
+	}
+
 	storage.WriteToDB()
 	return []byte("OK")
 }

--- a/internal/transport/tcp/handler/set_key.go
+++ b/internal/transport/tcp/handler/set_key.go
@@ -1,12 +1,18 @@
 package handler
 
 import (
+	"github.com/taymour/elysiandb/internal/globals"
 	"github.com/taymour/elysiandb/internal/log"
+	"github.com/taymour/elysiandb/internal/stat"
 	"github.com/taymour/elysiandb/internal/storage"
 	"github.com/taymour/elysiandb/internal/transport/tcp/parsing"
 )
 
 func HandleSet(query []byte, ttl int) []byte {
+	if globals.GetConfig().Stats.Enabled {
+		stat.Stats.IncrementTotalRequests()
+	}
+
 	k, v := parsing.FirstWordBytes(query)
 
 	key := string(k)

--- a/test/e2e/http/controller_test.go
+++ b/test/e2e/http/controller_test.go
@@ -1,6 +1,7 @@
 package e2e
 
 import (
+	"encoding/json"
 	"testing"
 	"time"
 
@@ -236,5 +237,135 @@ func TestPutAndReset(t *testing.T) {
 	}
 	if resp.StatusCode() != fasthttp.StatusNotFound {
 		t.Fatalf("expected 404 for missing key, got %d", resp.StatusCode())
+	}
+}
+
+func TestStats(t *testing.T) {
+	client, stop := startTestServer(t)
+	defer stop()
+
+	type StatsDTO struct {
+		KeysCount           string `json:"keys_count"`
+		ExpirationKeysCount string `json:"expiration_keys_count"`
+		UptimeSeconds       string `json:"uptime_seconds"`
+		TotalRequests       string `json:"total_requests"`
+		Hits                string `json:"hits"`
+		Misses              string `json:"misses"`
+	}
+
+	{
+		req := fasthttp.AcquireRequest()
+		resp := fasthttp.AcquireResponse()
+		defer fasthttp.ReleaseRequest(req)
+		defer fasthttp.ReleaseResponse(resp)
+
+		req.Header.SetMethod(fasthttp.MethodPut)
+		req.SetRequestURI("http://test/kv/foo")
+		req.SetBodyString("bar")
+		if err := client.Do(req, resp); err != nil {
+			t.Fatalf("PUT failed: %v", err)
+		}
+		if sc := resp.StatusCode(); sc != fasthttp.StatusNoContent {
+			t.Fatalf("expected 204, got %d", sc)
+		}
+	}
+
+	{
+		req := fasthttp.AcquireRequest()
+		resp := fasthttp.AcquireResponse()
+		defer fasthttp.ReleaseRequest(req)
+		defer fasthttp.ReleaseResponse(resp)
+
+		req.Header.SetMethod(fasthttp.MethodGet)
+		req.SetRequestURI("http://test/kv/foo")
+		if err := client.Do(req, resp); err != nil {
+			t.Fatalf("GET hit failed: %v", err)
+		}
+		if sc := resp.StatusCode(); sc != fasthttp.StatusOK {
+			t.Fatalf("expected 200, got %d", sc)
+		}
+	}
+
+	{
+		req := fasthttp.AcquireRequest()
+		resp := fasthttp.AcquireResponse()
+		defer fasthttp.ReleaseRequest(req)
+		defer fasthttp.ReleaseResponse(resp)
+
+		req.Header.SetMethod(fasthttp.MethodGet)
+		req.SetRequestURI("http://test/kv/missing")
+		if err := client.Do(req, resp); err != nil {
+			t.Fatalf("GET miss failed: %v", err)
+		}
+		if sc := resp.StatusCode(); sc != fasthttp.StatusNotFound {
+			t.Fatalf("expected 404, got %d", sc)
+		}
+	}
+
+	atoi := func(s string) uint64 {
+		var n uint64
+		for i := 0; i < len(s); i++ {
+			c := s[i]
+			if c < '0' || c > '9' {
+				t.Fatalf("expected numeric string, got %q", s)
+			}
+			n = n*10 + uint64(c-'0')
+		}
+		return n
+	}
+
+	getStats := func() StatsDTO {
+		req := fasthttp.AcquireRequest()
+		resp := fasthttp.AcquireResponse()
+		defer fasthttp.ReleaseRequest(req)
+		defer fasthttp.ReleaseResponse(resp)
+
+		req.Header.SetMethod(fasthttp.MethodGet)
+		req.SetRequestURI("http://test/stats")
+
+		if err := client.Do(req, resp); err != nil {
+			t.Fatalf("GET /stats failed: %v", err)
+		}
+		if sc := resp.StatusCode(); sc != fasthttp.StatusOK {
+			t.Fatalf("expected 200 from /stats, got %d", sc)
+		}
+
+		var dto StatsDTO
+		if err := json.Unmarshal(resp.Body(), &dto); err != nil {
+			t.Fatalf("invalid JSON from /stats: %v (body=%q)", err, resp.Body())
+		}
+
+		_ = atoi(dto.KeysCount)
+		_ = atoi(dto.ExpirationKeysCount)
+		_ = atoi(dto.UptimeSeconds)
+		_ = atoi(dto.TotalRequests)
+		_ = atoi(dto.Hits)
+		_ = atoi(dto.Misses)
+
+		return dto
+	}
+
+	s1 := getStats()
+
+	if kc := atoi(s1.KeysCount); kc != 1 {
+		t.Fatalf("keys_count = %d, want 1", kc)
+	}
+	if ec := atoi(s1.ExpirationKeysCount); ec != 0 {
+		t.Fatalf("expiration_keys_count = %d, want 0", ec)
+	}
+	_ = atoi(s1.UptimeSeconds)
+
+	h1 := atoi(s1.Hits)
+	m1 := atoi(s1.Misses)
+	tr1 := atoi(s1.TotalRequests)
+
+	if h1 < 1 {
+		t.Fatalf("hits = %d, want >= 1 (after GET on existing key)", h1)
+	}
+	if m1 < 1 {
+		t.Fatalf("misses = %d, want >= 1 (after GET on missing key)", m1)
+	}
+	if tr1 < h1+m1 {
+		t.Fatalf("total_requests = %d, want >= hits+misses (%d)", tr1, h1+m1)
 	}
 }

--- a/test/e2e/http/server_test.go
+++ b/test/e2e/http/server_test.go
@@ -22,6 +22,9 @@ func startTestServer(t *testing.T) (*fasthttp.Client, func()) {
 			Folder: tmp,
 			Shards: 8,
 		},
+		Stats: configuration.StatsConfig{
+			Enabled: true,
+		},
 	}
 	globals.SetConfig(cfg)
 	storage.LoadDB()

--- a/test/internal/stat_test/stat_test.go
+++ b/test/internal/stat_test/stat_test.go
@@ -1,0 +1,213 @@
+package stat_test
+
+import (
+	"encoding/json"
+	"sync"
+	"testing"
+
+	"github.com/taymour/elysiandb/internal/stat"
+)
+
+func TestNewStatsContainer_Zeroed(t *testing.T) {
+	s := stat.NewStatsContainer()
+
+	var m map[string]string
+	if err := json.Unmarshal([]byte(s.ToJson()), &m); err != nil {
+		t.Fatalf("json.Unmarshal failed: %v", err)
+	}
+
+	wantZero := map[string]string{
+		"keys_count":            "0",
+		"expiration_keys_count": "0",
+		"uptime_seconds":        "0",
+		"total_requests":        "0",
+		"hits":                  "0",
+		"misses":                "0",
+	}
+	for k, want := range wantZero {
+		if got := m[k]; got != want {
+			t.Errorf("field %q = %q, want %q", k, got, want)
+		}
+	}
+}
+
+func TestIncrementsAndSets(t *testing.T) {
+	s := stat.NewStatsContainer()
+
+	s.IncrementKeysCount()
+	s.IncrementExpirationKeysCount()
+	s.IncrementUptimeSeconds()
+	s.IncrementTotalRequests()
+	s.IncrementHits()
+	s.IncrementMisses()
+
+	s.SetKeysCount(42)
+	s.SetExpirationKeysCount(7)
+
+	var m map[string]string
+	if err := json.Unmarshal([]byte(s.ToJson()), &m); err != nil {
+		t.Fatalf("json.Unmarshal failed: %v", err)
+	}
+
+	tests := map[string]string{
+		"keys_count":            "42",
+		"expiration_keys_count": "7",
+		"uptime_seconds":        "1",
+		"total_requests":        "1",
+		"hits":                  "1",
+		"misses":                "1",
+	}
+	for k, want := range tests {
+		if got := m[k]; got != want {
+			t.Errorf("field %q = %q, want %q", k, got, want)
+		}
+	}
+}
+
+func TestDecrementDoesNotGoBelowZero(t *testing.T) {
+	s := stat.NewStatsContainer()
+
+	s.DecrementKeysCount()
+	s.DecrementExpirationKeysCount()
+
+	s.IncrementKeysCount()
+	s.IncrementExpirationKeysCount()
+	s.DecrementKeysCount()
+	s.DecrementExpirationKeysCount()
+
+	var m map[string]string
+	if err := json.Unmarshal([]byte(s.ToJson()), &m); err != nil {
+		t.Fatalf("json.Unmarshal failed: %v", err)
+	}
+	if m["keys_count"] != "0" {
+		t.Errorf("keys_count = %s, want 0", m["keys_count"])
+	}
+	if m["expiration_keys_count"] != "0" {
+		t.Errorf("expiration_keys_count = %s, want 0", m["expiration_keys_count"])
+	}
+}
+
+func TestReset(t *testing.T) {
+	s := stat.NewStatsContainer()
+
+	s.SetKeysCount(10)
+	s.SetExpirationKeysCount(5)
+	s.IncrementUptimeSeconds()
+	s.IncrementTotalRequests()
+	s.IncrementHits()
+	s.IncrementMisses()
+
+	s.Reset()
+
+	var m map[string]string
+	if err := json.Unmarshal([]byte(s.ToJson()), &m); err != nil {
+		t.Fatalf("json.Unmarshal failed: %v", err)
+	}
+	for k, v := range m {
+		if v != "0" {
+			t.Errorf("after Reset, %s = %s, want 0", k, v)
+		}
+	}
+}
+
+func TestToJSON_ValuesAreStrings(t *testing.T) {
+	s := stat.NewStatsContainer()
+	s.SetKeysCount(3)
+	s.SetExpirationKeysCount(4)
+	s.IncrementUptimeSeconds()
+	s.IncrementTotalRequests()
+	s.IncrementHits()
+	s.IncrementMisses()
+
+	var m map[string]interface{}
+	if err := json.Unmarshal([]byte(s.ToJson()), &m); err != nil {
+		t.Fatalf("json.Unmarshal failed: %v", err)
+	}
+	for k, v := range m {
+		if _, ok := v.(string); !ok {
+			t.Errorf("field %q is not a string in JSON (got %T: %v)", k, v, v)
+		}
+	}
+}
+
+func TestConcurrentIncrements_NoRaceAndCountsMatch(t *testing.T) {
+	s := stat.NewStatsContainer()
+
+	const goroutines = 64
+	const iters = 10_000
+
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+
+	for i := 0; i < goroutines; i++ {
+		go func() {
+			defer wg.Done()
+			for j := 0; j < iters; j++ {
+				s.IncrementKeysCount()
+				s.IncrementExpirationKeysCount()
+				s.IncrementTotalRequests()
+				s.IncrementHits()
+			}
+		}()
+	}
+
+	wg.Wait()
+
+	var m map[string]string
+	if err := json.Unmarshal([]byte(s.ToJson()), &m); err != nil {
+		t.Fatalf("json.Unmarshal failed: %v", err)
+	}
+
+	want := goroutines * iters
+	check := func(field string) {
+		if m[field] != itoa(want) {
+			t.Errorf("%s = %s, want %d", field, m[field], want)
+		}
+	}
+	check("keys_count")
+	check("expiration_keys_count")
+	check("total_requests")
+	check("hits")
+}
+
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	sign := ""
+	if n < 0 {
+		sign = "-"
+		n = -n
+	}
+	buf := [20]byte{}
+	i := len(buf)
+	for n > 0 {
+		i--
+		buf[i] = byte('0' + n%10)
+		n /= 10
+	}
+	if sign != "" {
+		i--
+		buf[i] = '-'
+	}
+	return string(buf[i:])
+}
+
+func TestInit_GlobalStatsIsZeroed(t *testing.T) {
+	stat.Stats.IncrementHits()
+	stat.Stats.IncrementMisses()
+	stat.Stats.SetKeysCount(9)
+	stat.Stats.SetExpirationKeysCount(2)
+
+	stat.Init()
+
+	var m map[string]string
+	if err := json.Unmarshal([]byte(stat.Stats.ToJson()), &m); err != nil {
+		t.Fatalf("json.Unmarshal failed: %v", err)
+	}
+	for k, v := range m {
+		if v != "0" {
+			t.Errorf("after Init, %s = %s, want 0", k, v)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
Add lightweight, lock‑free runtime counters (using 64‑bit atomics) and expose them via **`GET /stats`** when `stats.enabled: true`.

## What’s included

* New config flag: `stats.enabled` (defaults to `false`).
* HTTP endpoint: **`GET /stats`** → JSON payload with string‑encoded counters:

  * `keys_count`, `expiration_keys_count`, `uptime_seconds`, `total_requests`, `hits`, `misses`.
* Counters updated in both HTTP and TCP handlers with **atomic.Uint64** (no locks, safe under concurrency).
* Uptime ticker increments once per second.
* Stats are seeded on startup from current store/expirations.
* README updated with usage + examples.
* Tests: unit tests for stats + e2e test for `/stats`.

## Why
Provide observability with **near‑zero overhead** and no external dependencies.

## Notes

* The endpoint is available only if the HTTP server is enabled.
* JSON numbers are emitted as strings to avoid precision loss in some clients.

**Backward compatibility**

* Disabled by default; no behavior change unless `stats.enabled` is turned on.

Closes https://github.com/taymour/elysiandb/issues/12