### PR TITLE
Added wildcard support for del command in http & tcp

### DIFF
--- a/internal/transport/http/controller/delete_key.go
+++ b/internal/transport/http/controller/delete_key.go
@@ -2,10 +2,12 @@ package controller
 
 import (
 	"net/http"
+	"net/url"
 
 	"github.com/taymour/elysiandb/internal/globals"
 	"github.com/taymour/elysiandb/internal/stat"
 	"github.com/taymour/elysiandb/internal/storage"
+	"github.com/taymour/elysiandb/internal/wildcard"
 	"github.com/valyala/fasthttp"
 )
 
@@ -15,6 +17,16 @@ func DeleteKeyController(ctx *fasthttp.RequestCtx) {
 	}
 
 	key := ctx.UserValue("key").(string)
-	storage.DeleteByKey(key)
+
+	if dec, err := url.PathUnescape(key); err == nil {
+		key = dec
+	}
+
+	if wildcard.KeyContainsWildcard(key) {
+		storage.DeleteByWildcardKey(key)
+	} else {
+		storage.DeleteByKey(key)
+	}
+
 	ctx.SetStatusCode(http.StatusNoContent)
 }

--- a/internal/transport/tcp/handler/delete_key.go
+++ b/internal/transport/tcp/handler/delete_key.go
@@ -1,9 +1,12 @@
 package handler
 
 import (
+	"fmt"
+
 	"github.com/taymour/elysiandb/internal/globals"
 	"github.com/taymour/elysiandb/internal/stat"
 	"github.com/taymour/elysiandb/internal/storage"
+	"github.com/taymour/elysiandb/internal/wildcard"
 )
 
 func HandleDelete(query []byte) []byte {
@@ -11,6 +14,23 @@ func HandleDelete(query []byte) []byte {
 		stat.Stats.IncrementTotalRequests()
 	}
 
-	storage.DeleteByKey(string(query))
-	return []byte("OK")
+	key := string(query)
+
+	var count int
+	if wildcard.KeyContainsWildcard(key) {
+		count = handleWildcardKeyDelete(key)
+	} else {
+		count = handleSingleKeyDelete(key)
+	}
+
+	return []byte(fmt.Sprintf("Deleted %d", count))
+}
+
+func handleSingleKeyDelete(key string) int {
+	storage.DeleteByKey(key)
+	return 1
+}
+
+func handleWildcardKeyDelete(pattern string) int {
+	return storage.DeleteByWildcardKey(pattern)
 }

--- a/test/e2e/tcp/tcp_test.go
+++ b/test/e2e/tcp/tcp_test.go
@@ -148,6 +148,25 @@ func TestTCP_PING_SET_MGET_GET__WILDCARD__SAVE__RESET(t *testing.T) {
 		t.Fatalf("MGET mixed last line: want %q, got %q (all=%v)", "zoo=not found", mixed[3], mixed)
 	}
 
+	write("DEL user:*")
+	if got := readLine(); got != "Deleted 2" {
+		t.Fatalf("after DEL user:* want %q, got %q", "Deleted 2", got)
+	}
+
+	write("GET user:*")
+	if got := readLine(); got != "user:*=not found" {
+		t.Fatalf("GET user:* after delete: want %q, got %q", "user:*=not found", got)
+	}
+
+	write("MGET user:* foo")
+	afterDel := readN(2)
+	if afterDel[0] != "user:*=not found" {
+		t.Fatalf("MGET user:* foo [0]: want %q, got %q (all=%v)", "user:*=not found", afterDel[0], afterDel)
+	}
+	if afterDel[1] != "hello" {
+		t.Fatalf("MGET user:* foo [1]: want %q, got %q (all=%v)", "hello", afterDel[1], afterDel)
+	}
+
 	write("SAVE")
 	if got := readLine(); got != "OK" {
 		t.Fatalf("want OK, got %q", got)
@@ -166,5 +185,20 @@ func TestTCP_PING_SET_MGET_GET__WILDCARD__SAVE__RESET(t *testing.T) {
 	write("GET foo")
 	if got := readLine(); got != "foo=not found" {
 		t.Fatalf("want %q, got %q", "foo=not found", got)
+	}
+
+	write("SET to_delete hello")
+	if got := readLine(); got != "OK" {
+		t.Fatalf("want OK, got %q", got)
+	}
+
+	write("DEL to_delete")
+	if got := readLine(); got != "Deleted 1" {
+		t.Fatalf("after DEL to_delete want %q, got %q", "Deleted 1", got)
+	}
+
+	write("GET to_delete")
+	if got := readLine(); got != "to_delete=not found" {
+		t.Fatalf("want %q, got %q", "to_delete=not found", got)
 	}
 }


### PR DESCRIPTION
**Summary**
Enable deleting multiple keys using `*` patterns across HTTP and TCP.

**HTTP**

* `DELETE /kv/{pattern}`
* Returns ad before response 204 no content

**TCP**

* `DEL <pattern>`
* Returns `Deleted <int>`.

**Notes**

* Shard‑safe scan with simple glob matcher; no persistence format change.

Closes https://github.com/taymour/elysiandb/issues/19