### PR TITLE
Added filters exact match for instant rest api

### DIFF
--- a/internal/api/filter.go
+++ b/internal/api/filter.go
@@ -1,0 +1,18 @@
+package api_storage
+
+func FiltersMatchEntity(
+	entityData map[string]interface{},
+	filters map[string]string,
+) bool {
+	if len(filters) == 0 {
+		return true
+	}
+
+	for field, value := range filters {
+		if entityData[field] != value {
+			return false
+		}
+	}
+
+	return true
+}

--- a/internal/api/sort.go
+++ b/internal/api/sort.go
@@ -5,7 +5,7 @@ import (
 )
 
 func GetSortedEntityIdsByField(entity string, field string, ascending bool) []string {
-	data := ListEntities(entity, 0, 0, "", true)
+	data := ListEntities(entity, 0, 0, "", true, map[string]string{})
 	sort.Slice(data, func(i, j int) bool {
 		a, b := data[i][field], data[j][field]
 		switch va := a.(type) {

--- a/internal/transport/http/api/list.go
+++ b/internal/transport/http/api/list.go
@@ -13,8 +13,9 @@ func ListController(ctx *fasthttp.RequestCtx) {
 	limit := ctx.QueryArgs().GetUintOrZero("limit")
 	offset := ctx.QueryArgs().GetUintOrZero("offset")
 	sortField, sortAscending := ParseSortParam(ctx.QueryArgs())
+	filters := ParseFilterParam(ctx.QueryArgs())
 
-	data := api_storage.ListEntities(entity, limit, offset, sortField, sortAscending)
+	data := api_storage.ListEntities(entity, limit, offset, sortField, sortAscending, filters)
 
 	response, err := json.Marshal(data)
 	if err != nil {
@@ -50,4 +51,17 @@ func ParseSortParam(params *fasthttp.Args) (field string, ascending bool) {
 	}
 
 	return field, ascending
+}
+
+func ParseFilterParam(params *fasthttp.Args) map[string]string {
+	filters := make(map[string]string)
+	for k, v := range params.All() {
+		key := string(k)
+		if strings.HasPrefix(key, "filter[") && strings.HasSuffix(key, "]") {
+			field := key[len("filter[") : len(key)-1]
+			value := strings.TrimSpace(string(v))
+			filters[field] = value
+		}
+	}
+	return filters
 }


### PR DESCRIPTION
Add support for exact match filters in the instant REST API.

Clients can now use query parameters like filter[field]=value to retrieve only entities where the given field matches the exact value. Multiple filters can be combined across fields, and results are returned only when all filters match (logical AND). This extends the REST API’s flexibility alongside pagination and sorting.

Closes https://github.com/elysiandb/elysiandb/issues/26