### PR TITLE
Added filter eq/neq to instant rest api

### DIFF
--- a/internal/api/filter.go
+++ b/internal/api/filter.go
@@ -1,23 +1,59 @@
 package api_storage
 
-import "github.com/taymour/elysiandb/internal/storage"
+import (
+	"strings"
+
+	"github.com/taymour/elysiandb/internal/storage"
+)
+
+func getNestedValue(data map[string]interface{}, path string) (string, bool) {
+	parts := strings.Split(path, ".")
+	var current interface{} = data
+	for _, part := range parts {
+		m, ok := current.(map[string]interface{})
+		if !ok {
+			return "", false
+		}
+		
+		current, ok = m[part]
+		if !ok {
+			return "", false
+		}
+	}
+
+	strVal, isString := current.(string)
+	if !isString {
+		return "", false
+	}
+
+	return strVal, true
+}
 
 func FiltersMatchEntity(
 	entityData map[string]interface{},
-	filters map[string]string,
+	filters map[string]map[string]string,
 ) bool {
 	if len(filters) == 0 {
 		return true
 	}
 
-	for field, value := range filters {
-		entityVal, ok := entityData[field]
-		strVal, isString := entityVal.(string)
-		if !ok || !isString {
+	for field, ops := range filters {
+		strVal, ok := getNestedValue(entityData, field)
+		if !ok {
 			return false
 		}
-		if !storage.MatchGlob(value, strVal) {
-			return false
+
+		for op, val := range ops {
+			switch op {
+			case "eq":
+				if !storage.MatchGlob(val, strVal) {
+					return false
+				}
+			case "neq":
+				if storage.MatchGlob(val, strVal) {
+					return false
+				}
+			}
 		}
 	}
 

--- a/internal/api/sort.go
+++ b/internal/api/sort.go
@@ -5,7 +5,7 @@ import (
 )
 
 func GetSortedEntityIdsByField(entity string, field string, ascending bool) []string {
-	data := ListEntities(entity, 0, 0, "", true, map[string]string{})
+	data := ListEntities(entity, 0, 0, "", true, map[string]map[string]string{})
 	sort.Slice(data, func(i, j int) bool {
 		a, b := data[i][field], data[j][field]
 		switch va := a.(type) {

--- a/internal/api/storage.go
+++ b/internal/api/storage.go
@@ -22,7 +22,7 @@ func ListEntities(
 	offset int,
 	sortField string,
 	sortAscending bool,
-	filters map[string]string,
+	filters map[string]map[string]string,
 ) []map[string]interface{} {
 	idList, err := GetListOfIds(entity, sortField, sortAscending)
 	if err != nil {

--- a/internal/storage/wildcard.go
+++ b/internal/storage/wildcard.go
@@ -1,5 +1,7 @@
 package storage
 
+import "strings"
+
 func isBareStar(p string) bool {
 	if len(p) != 1 {
 		return false
@@ -8,6 +10,8 @@ func isBareStar(p string) bool {
 }
 
 func MatchGlob(pattern string, s string) bool {
+	pattern = strings.ToLower(pattern)
+	s = strings.ToLower(s)
 	p := pattern
 	i, j := 0, 0
 	star := -1


### PR DESCRIPTION
### PR Description

This PR adds support for `eq` and `neq` string filters in the instant REST API. Users can now query entities using equality and inequality filters, including nested fields (e.g. `author.name` or `author.category.title`). Filters are case-insensitive.

#### Examples

* `GET /api/books?filter[author][eq]=Alice` → returns all books written by Alice
* `GET /api/books?filter[author][neq]=Alice` → returns all books not written by Alice
* `GET /api/articles?filter[author.name][eq]=mister*` → case-insensitive wildcard match on nested field
* `GET /api/articles?filter[author.category.title][eq]=yep` → match on deeply nested field

Closes [https://github.com/elysiandb/elysiandb/issues/34](https://github.com/elysiandb/elysiandb/issues/34)
Closes [https://github.com/elysiandb/elysiandb/issues/33](https://github.com/elysiandb/elysiandb/issues/33)

