### PR TITLE
Added support to filter numbers

### DIFF
--- a/internal/api/filter.go
+++ b/internal/api/filter.go
@@ -1,32 +1,28 @@
 package api_storage
 
 import (
+	"strconv"
 	"strings"
 
 	"github.com/taymour/elysiandb/internal/storage"
 )
 
-func getNestedValue(data map[string]interface{}, path string) (string, bool) {
+func getNestedValue(data map[string]interface{}, path string) (interface{}, bool) {
 	parts := strings.Split(path, ".")
 	var current interface{} = data
 	for _, part := range parts {
 		m, ok := current.(map[string]interface{})
 		if !ok {
-			return "", false
+			return nil, false
 		}
-		
+
 		current, ok = m[part]
 		if !ok {
-			return "", false
+			return nil, false
 		}
 	}
-
-	strVal, isString := current.(string)
-	if !isString {
-		return "", false
-	}
-
-	return strVal, true
+	
+	return current, true
 }
 
 func FiltersMatchEntity(
@@ -38,22 +34,60 @@ func FiltersMatchEntity(
 	}
 
 	for field, ops := range filters {
-		strVal, ok := getNestedValue(entityData, field)
+		val, ok := getNestedValue(entityData, field)
 		if !ok {
 			return false
 		}
 
-		for op, val := range ops {
-			switch op {
-			case "eq":
-				if !storage.MatchGlob(val, strVal) {
-					return false
-				}
-			case "neq":
-				if storage.MatchGlob(val, strVal) {
-					return false
+		switch v := val.(type) {
+		case string:
+			for op, cmp := range ops {
+				switch op {
+				case "eq":
+					if !storage.MatchGlob(cmp, v) {
+						return false
+					}
+				case "neq":
+					if storage.MatchGlob(cmp, v) {
+						return false
+					}
 				}
 			}
+		case float64:
+			for op, cmp := range ops {
+				num, err := strconv.ParseFloat(cmp, 64)
+				if err != nil {
+					return false
+				}
+				switch op {
+				case "eq":
+					if v != num {
+						return false
+					}
+				case "neq":
+					if v == num {
+						return false
+					}
+				case "lt":
+					if !(v < num) {
+						return false
+					}
+				case "lte":
+					if !(v <= num) {
+						return false
+					}
+				case "gt":
+					if !(v > num) {
+						return false
+					}
+				case "gte":
+					if !(v >= num) {
+						return false
+					}
+				}
+			}
+		default:
+			return false
 		}
 	}
 

--- a/test/internal/api_test/storage_test.go
+++ b/test/internal/api_test/storage_test.go
@@ -286,3 +286,48 @@ func TestListEntities_WithNestedFilters(t *testing.T) {
 		t.Fatalf("expected only a1 for combined eq/neq, got %v", r4)
 	}
 }
+
+func TestListEntities_WithNumericFilters(t *testing.T) {
+	initTestStore(t)
+
+	entity := "products"
+	api_storage.WriteEntity(entity, map[string]interface{}{"id": "p1", "price": 10})
+	api_storage.WriteEntity(entity, map[string]interface{}{"id": "p2", "price": 20})
+	api_storage.WriteEntity(entity, map[string]interface{}{"id": "p3", "price": 30})
+
+	f1 := map[string]map[string]string{"price": {"eq": "20"}}
+	r1 := api_storage.ListEntities(entity, 0, 0, "", true, f1)
+	if len(r1) != 1 || r1[0]["id"] != "p2" {
+		t.Fatalf("expected only p2 for eq=20, got %v", r1)
+	}
+
+	f2 := map[string]map[string]string{"price": {"neq": "20"}}
+	r2 := api_storage.ListEntities(entity, 0, 0, "", true, f2)
+	if len(r2) != 2 {
+		t.Fatalf("expected 2 results for neq=20, got %v", r2)
+	}
+
+	f3 := map[string]map[string]string{"price": {"lt": "20"}}
+	r3 := api_storage.ListEntities(entity, 0, 0, "", true, f3)
+	if len(r3) != 1 || r3[0]["id"] != "p1" {
+		t.Fatalf("expected only p1 for lt=20, got %v", r3)
+	}
+
+	f4 := map[string]map[string]string{"price": {"lte": "20"}}
+	r4 := api_storage.ListEntities(entity, 0, 0, "", true, f4)
+	if len(r4) != 2 {
+		t.Fatalf("expected p1 and p2 for lte=20, got %v", r4)
+	}
+
+	f5 := map[string]map[string]string{"price": {"gt": "20"}}
+	r5 := api_storage.ListEntities(entity, 0, 0, "", true, f5)
+	if len(r5) != 1 || r5[0]["id"] != "p3" {
+		t.Fatalf("expected only p3 for gt=20, got %v", r5)
+	}
+
+	f6 := map[string]map[string]string{"price": {"gte": "20"}}
+	r6 := api_storage.ListEntities(entity, 0, 0, "", true, f6)
+	if len(r6) != 2 {
+		t.Fatalf("expected p2 and p3 for gte=20, got %v", r6)
+	}
+}


### PR DESCRIPTION
This PR adds numeric filter support (`eq`, `neq`, `lt`, `lte`, `gt`, `gte`) in the instant REST API.
String fields continue to support only `eq` and `neq`.

#### Examples

* `GET /api/products?filter[price][lt]=100` → products with price < 100
* `GET /api/products?filter[price][gte]=50` → products with price ≥ 50
* `GET /api/books?filter[author][eq]=Alice` → books authored by Alice

Closes https://github.com/elysiandb/elysiandb/issues/37