### PR TITLE
Added fields param for instant rest api

### DIFF
--- a/internal/api/field.go
+++ b/internal/api/field.go
@@ -1,0 +1,59 @@
+package api_storage
+
+import "strings"
+
+func GetNestedValue(data map[string]interface{}, path string) (interface{}, bool) {
+	parts := strings.Split(path, ".")
+	var current interface{} = data
+	for _, part := range parts {
+		m, ok := current.(map[string]interface{})
+		if !ok {
+			return nil, false
+		}
+		current, ok = m[part]
+		if !ok {
+			return nil, false
+		}
+	}
+	return current, true
+}
+
+func SetNestedField(dest map[string]interface{}, path string, value interface{}) {
+	parts := strings.Split(path, ".")
+	current := dest
+	for i, part := range parts {
+		if i == len(parts)-1 {
+			current[part] = value
+			return
+		}
+		if _, ok := current[part]; !ok {
+			current[part] = make(map[string]interface{})
+		}
+		current = current[part].(map[string]interface{})
+	}
+}
+
+func FilterFields(data map[string]interface{}, fields []string) map[string]interface{} {
+	filtered := make(map[string]interface{})
+	for _, field := range fields {
+		if value, ok := GetNestedValue(data, field); ok {
+			SetNestedField(filtered, field, value)
+		}
+	}
+	return filtered
+}
+
+func ParseFieldsParam(param string) []string {
+	if param == "" {
+		return nil
+	}
+	parts := strings.Split(param, ",")
+	fields := make([]string, 0, len(parts))
+	for _, part := range parts {
+		part = strings.TrimSpace(part)
+		if part != "" {
+			fields = append(fields, part)
+		}
+	}
+	return fields
+}

--- a/internal/api/filter.go
+++ b/internal/api/filter.go
@@ -2,29 +2,10 @@ package api_storage
 
 import (
 	"strconv"
-	"strings"
 	"time"
 
 	"github.com/taymour/elysiandb/internal/storage"
 )
-
-func GetNestedValue(data map[string]interface{}, path string) (interface{}, bool) {
-	parts := strings.Split(path, ".")
-	var current interface{} = data
-	for _, part := range parts {
-		m, ok := current.(map[string]interface{})
-		if !ok {
-			return nil, false
-		}
-
-		current, ok = m[part]
-		if !ok {
-			return nil, false
-		}
-	}
-
-	return current, true
-}
 
 func FiltersMatchEntity(
 	entityData map[string]interface{},

--- a/internal/cache/cache.go
+++ b/internal/cache/cache.go
@@ -114,11 +114,13 @@ func (s *cacheStore) Purge(entity string) {
 	s.mu.Unlock()
 }
 
-func HashQuery(entity string, limit, offset int, sortField string, sortAscending bool, filters map[string]map[string]string) []byte {
+func HashQuery(entity string, limit, offset int, sortField string, sortAscending bool, filters map[string]map[string]string, fieldsParam string) []byte {
 	var b []byte
 	b = append(b, entity...)
 	b = append(b, '|')
 	b = append(b, sortField...)
+	b = append(b, '|')
+	b = append(b, fieldsParam...)
 	b = append(b, '|')
 	if sortAscending {
 		b = append(b, 'A')

--- a/test/internal/api_test/field_test.go
+++ b/test/internal/api_test/field_test.go
@@ -1,0 +1,101 @@
+package api_test
+
+import (
+	"reflect"
+	"testing"
+
+	api_storage "github.com/taymour/elysiandb/internal/api"
+)
+
+func TestFieldGetNestedValue(t *testing.T) {
+	data := map[string]interface{}{
+		"name": "John",
+		"address": map[string]interface{}{
+			"city":  "Paris",
+			"geo":   map[string]interface{}{"lat": 48.85, "lng": 2.35},
+			"empty": map[string]interface{}{},
+		},
+	}
+
+	tests := []struct {
+		path     string
+		expected interface{}
+		found    bool
+	}{
+		{"name", "John", true},
+		{"address.city", "Paris", true},
+		{"address.geo.lat", 48.85, true},
+		{"address.geo.lng", 2.35, true},
+		{"address.geo.missing", nil, false},
+		{"missing", nil, false},
+		{"address.empty", map[string]interface{}{}, true},
+	}
+
+	for _, tt := range tests {
+		got, ok := api_storage.GetNestedValue(data, tt.path)
+		if ok != tt.found {
+			t.Errorf("GetNestedValue(%q) found=%v, want %v", tt.path, ok, tt.found)
+		}
+		if ok && !reflect.DeepEqual(got, tt.expected) {
+			t.Errorf("GetNestedValue(%q)=%v, want %v", tt.path, got, tt.expected)
+		}
+	}
+}
+
+func TestSetNestedField(t *testing.T) {
+	dest := make(map[string]interface{})
+	api_storage.FilterFields(map[string]interface{}{}, []string{}) // force package load
+	api_storage.SetNestedField(dest, "a.b.c", 42)
+	expected := map[string]interface{}{
+		"a": map[string]interface{}{
+			"b": map[string]interface{}{
+				"c": 42,
+			},
+		},
+	}
+	if !reflect.DeepEqual(dest, expected) {
+		t.Errorf("SetNestedField result=%v, want %v", dest, expected)
+	}
+}
+
+func TestFilterFields(t *testing.T) {
+	data := map[string]interface{}{
+		"id":   "u1",
+		"name": "Alice",
+		"address": map[string]interface{}{
+			"city": "Paris",
+			"geo":  map[string]interface{}{"lat": 48.85, "lng": 2.35},
+		},
+	}
+	fields := []string{"id", "address.geo.lat"}
+	got := api_storage.FilterFields(data, fields)
+	expected := map[string]interface{}{
+		"id": "u1",
+		"address": map[string]interface{}{
+			"geo": map[string]interface{}{
+				"lat": 48.85,
+			},
+		},
+	}
+	if !reflect.DeepEqual(got, expected) {
+		t.Errorf("FilterFields=%v, want %v", got, expected)
+	}
+}
+
+func TestParseFieldsParam(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected []string
+	}{
+		{"name,email", []string{"name", "email"}},
+		{" name , address.city ", []string{"name", "address.city"}},
+		{"", nil},
+		{",,,", []string{}},
+	}
+	for _, tt := range tests {
+		got := api_storage.ParseFieldsParam(tt.input)
+		if !reflect.DeepEqual(got, tt.expected) {
+			t.Errorf("ParseFieldsParam(%q)=%v, want %v", tt.input, got, tt.expected)
+		}
+	}
+}

--- a/test/internal/cache_test/cache_test.go
+++ b/test/internal/cache_test/cache_test.go
@@ -10,7 +10,7 @@ import (
 func TestCacheSetGet(t *testing.T) {
 	cache.InitCache(10 * time.Second)
 	entity := "users"
-	hash := cache.HashQuery("users", 10, 0, "name", true, nil)
+	hash := cache.HashQuery("users", 10, 0, "name", true, nil, "")
 	value := []byte(`{"id":"1","name":"Alice"}`)
 	cache.CacheStore.Set(entity, hash, value)
 	got := cache.CacheStore.Get(entity, hash)
@@ -22,7 +22,7 @@ func TestCacheSetGet(t *testing.T) {
 func TestCacheGetNotExist(t *testing.T) {
 	cache.InitCache(10 * time.Second)
 	entity := "users"
-	hash := cache.HashQuery("users", 10, 0, "name", true, nil)
+	hash := cache.HashQuery("users", 10, 0, "name", true, nil, "")
 	got := cache.CacheStore.Get(entity, hash)
 	if got != nil {
 		t.Fatalf("expected nil, got %s", got)
@@ -42,7 +42,7 @@ func TestCacheInvalidHashLength(t *testing.T) {
 func TestCachePurge(t *testing.T) {
 	cache.InitCache(10 * time.Second)
 	entity := "users"
-	hash := cache.HashQuery("users", 10, 0, "name", true, nil)
+	hash := cache.HashQuery("users", 10, 0, "name", true, nil, "")
 	value := []byte(`{"id":"1"}`)
 	cache.CacheStore.Set(entity, hash, value)
 	cache.CacheStore.Purge(entity)
@@ -53,20 +53,20 @@ func TestCachePurge(t *testing.T) {
 }
 
 func TestHashQueryDifferentInputs(t *testing.T) {
-	h1 := cache.HashQuery("users", 10, 0, "name", true, nil)
-	h2 := cache.HashQuery("users", 20, 0, "name", true, nil)
+	h1 := cache.HashQuery("users", 10, 0, "name", true, nil, "")
+	h2 := cache.HashQuery("users", 20, 0, "name", true, nil, "")
 	if string(h1) == string(h2) {
 		t.Fatalf("expected different hashes for different limits")
 	}
-	h3 := cache.HashQuery("users", 10, 5, "name", true, nil)
+	h3 := cache.HashQuery("users", 10, 5, "name", true, nil, "")
 	if string(h1) == string(h3) {
 		t.Fatalf("expected different hashes for different offsets")
 	}
-	h4 := cache.HashQuery("users", 10, 0, "name", false, nil)
+	h4 := cache.HashQuery("users", 10, 0, "name", false, nil, "")
 	if string(h1) == string(h4) {
 		t.Fatalf("expected different hashes for ascending vs descending")
 	}
-	h5 := cache.HashQuery("users", 10, 0, "age", true, nil)
+	h5 := cache.HashQuery("users", 10, 0, "age", true, nil, "")
 	if string(h1) == string(h5) {
 		t.Fatalf("expected different hashes for different sort fields")
 	}
@@ -82,9 +82,9 @@ func TestHashQueryWithFiltersStringOps(t *testing.T) {
 	f3 := map[string]map[string]string{
 		"name": {"eq": "Bob"},
 	}
-	h1 := cache.HashQuery("users", 10, 0, "name", true, f1)
-	h2 := cache.HashQuery("users", 10, 0, "name", true, f2)
-	h3 := cache.HashQuery("users", 10, 0, "name", true, f3)
+	h1 := cache.HashQuery("users", 10, 0, "name", true, f1, "")
+	h2 := cache.HashQuery("users", 10, 0, "name", true, f2, "")
+	h3 := cache.HashQuery("users", 10, 0, "name", true, f3, "")
 	if string(h1) == string(h2) {
 		t.Fatalf("expected different hashes for eq vs neq")
 	}
@@ -106,10 +106,10 @@ func TestHashQueryWithFiltersNumericOps(t *testing.T) {
 	f4 := map[string]map[string]string{
 		"age": {"gte": "30"},
 	}
-	h1 := cache.HashQuery("users", 10, 0, "age", true, f1)
-	h2 := cache.HashQuery("users", 10, 0, "age", true, f2)
-	h3 := cache.HashQuery("users", 10, 0, "age", true, f3)
-	h4 := cache.HashQuery("users", 10, 0, "age", true, f4)
+	h1 := cache.HashQuery("users", 10, 0, "age", true, f1, "")
+	h2 := cache.HashQuery("users", 10, 0, "age", true, f2, "")
+	h3 := cache.HashQuery("users", 10, 0, "age", true, f3, "")
+	h4 := cache.HashQuery("users", 10, 0, "age", true, f4, "")
 	if string(h1) == string(h2) {
 		t.Fatalf("expected different hashes for lt vs lte")
 	}
@@ -130,8 +130,8 @@ func TestHashQueryWithMultipleFilters(t *testing.T) {
 		"name": {"eq": "Alice"},
 		"age":  {"gte": "30"},
 	}
-	h1 := cache.HashQuery("users", 10, 0, "name", true, f1)
-	h2 := cache.HashQuery("users", 10, 0, "name", true, f2)
+	h1 := cache.HashQuery("users", 10, 0, "name", true, f1, "")
+	h2 := cache.HashQuery("users", 10, 0, "name", true, f2, "")
 	if string(h1) == string(h2) {
 		t.Fatalf("expected different hashes for different filter values on age")
 	}
@@ -144,17 +144,17 @@ func TestHashQueryWithNestedFilters(t *testing.T) {
 	f2 := map[string]map[string]string{
 		"profile.age": {"lt": "40"},
 	}
-	h1 := cache.HashQuery("users", 10, 0, "profile.name", true, f1)
-	h2 := cache.HashQuery("users", 10, 0, "profile.age", true, f2)
+	h1 := cache.HashQuery("users", 10, 0, "profile.name", true, f1, "")
+	h2 := cache.HashQuery("users", 10, 0, "profile.age", true, f2, "")
 	if string(h1) == string(h2) {
 		t.Fatalf("expected different hashes for nested filters with different fields")
 	}
 }
 
 func TestHashQueryWithNestedSort(t *testing.T) {
-	h1 := cache.HashQuery("users", 10, 0, "profile.name", true, nil)
-	h2 := cache.HashQuery("users", 10, 0, "profile.name", false, nil)
-	h3 := cache.HashQuery("users", 10, 0, "profile.age", true, nil)
+	h1 := cache.HashQuery("users", 10, 0, "profile.name", true, nil, "")
+	h2 := cache.HashQuery("users", 10, 0, "profile.name", false, nil, "")
+	h3 := cache.HashQuery("users", 10, 0, "profile.age", true, nil, "")
 	if string(h1) == string(h2) {
 		t.Fatalf("expected different hashes for asc vs desc on nested field")
 	}
@@ -166,7 +166,7 @@ func TestHashQueryWithNestedSort(t *testing.T) {
 func TestCacheExpiration(t *testing.T) {
 	cache.InitCache(100 * time.Millisecond)
 	entity := "users"
-	hash := cache.HashQuery("users", 10, 0, "name", true, nil)
+	hash := cache.HashQuery("users", 10, 0, "name", true, nil, "")
 	value := []byte(`{"id":"1","name":"Alice"}`)
 	cache.CacheStore.Set(entity, hash, value)
 	time.Sleep(200 * time.Millisecond)
@@ -216,7 +216,7 @@ func TestCacheExpirationById(t *testing.T) {
 func TestCacheCleanExpiredRemovesBothDataAndIds(t *testing.T) {
 	cache.InitCache(10 * time.Millisecond)
 	entity := "users"
-	hash := cache.HashQuery("users", 10, 0, "name", true, nil)
+	hash := cache.HashQuery("users", 10, 0, "name", true, nil, "")
 	cache.CacheStore.Set(entity, hash, []byte("val"))
 	cache.CacheStore.SetById(entity, "id1", []byte("val"))
 	time.Sleep(20 * time.Millisecond)


### PR DESCRIPTION
**Title:**
Allow instant REST API `?fields=name,email` to return only specific and nested fields (#50)

**Description:**
This PR adds support for field projection in the instant REST API.
Clients can now specify the `fields` query parameter (e.g. `?fields=name,email,address.city`) to retrieve only selected fields, including nested ones.

* Added `internal/api/field.go` for field filtering utilities
* Updated `ListController` and `GetByIdController` to apply field filtering
* Extended cache hashing to include the `fields` parameter
* Added comprehensive unit tests for nested field extraction and filtering

Closes #50
