### PR TITLE
Added filters for arrays with multiple operations

### DIFF
--- a/test/internal/api_test/filter_test.go
+++ b/test/internal/api_test/filter_test.go
@@ -252,3 +252,100 @@ func TestFiltersMatchEntityInvalidCases(t *testing.T) {
 		t.Fatalf("expected false for unparsable date")
 	}
 }
+
+func TestFiltersMatchEntityArrayContains(t *testing.T) {
+	entity := map[string]interface{}{"tags": []interface{}{"toto", "tata", "titi"}}
+	f := map[string]map[string]string{"tags": {"contains": "toto"}}
+	if !api_storage.FiltersMatchEntity(entity, f) {
+		t.Fatalf("expected contains match")
+	}
+	f = map[string]map[string]string{"tags": {"contains": "tutu"}}
+	if api_storage.FiltersMatchEntity(entity, f) {
+		t.Fatalf("expected contains fail")
+	}
+}
+
+func TestFiltersMatchEntityArrayNotContains(t *testing.T) {
+	entity := map[string]interface{}{"tags": []interface{}{"toto", "tata", "titi"}}
+	f := map[string]map[string]string{"tags": {"not_contains": "tutu"}}
+	if !api_storage.FiltersMatchEntity(entity, f) {
+		t.Fatalf("expected not_contains match")
+	}
+	f = map[string]map[string]string{"tags": {"not_contains": "toto"}}
+	if api_storage.FiltersMatchEntity(entity, f) {
+		t.Fatalf("expected not_contains fail")
+	}
+}
+
+func TestFiltersMatchEntityArrayAll(t *testing.T) {
+	entity := map[string]interface{}{"tags": []interface{}{"toto", "tata", "titi"}}
+	f := map[string]map[string]string{"tags": {"all": "toto,tata"}}
+	if !api_storage.FiltersMatchEntity(entity, f) {
+		t.Fatalf("expected all match")
+	}
+	f = map[string]map[string]string{"tags": {"all": "toto,tutu"}}
+	if api_storage.FiltersMatchEntity(entity, f) {
+		t.Fatalf("expected all fail")
+	}
+}
+
+func TestFiltersMatchEntityArrayAny(t *testing.T) {
+	entity := map[string]interface{}{"tags": []interface{}{"toto", "tata", "titi"}}
+	f := map[string]map[string]string{"tags": {"any": "tutu,tata"}}
+	if !api_storage.FiltersMatchEntity(entity, f) {
+		t.Fatalf("expected any match")
+	}
+	f = map[string]map[string]string{"tags": {"any": "tutu,tete"}}
+	if api_storage.FiltersMatchEntity(entity, f) {
+		t.Fatalf("expected any fail")
+	}
+}
+
+func TestFiltersMatchEntityArrayEq(t *testing.T) {
+	entity := map[string]interface{}{"tags": []interface{}{"toto", "tata", "titi"}}
+	f := map[string]map[string]string{"tags": {"eq": "toto,tata,titi"}}
+	if !api_storage.FiltersMatchEntity(entity, f) {
+		t.Fatalf("expected eq match")
+	}
+	f = map[string]map[string]string{"tags": {"eq": "toto,tata"}}
+	if api_storage.FiltersMatchEntity(entity, f) {
+		t.Fatalf("expected eq fail length mismatch")
+	}
+	f = map[string]map[string]string{"tags": {"eq": "toto,titi,tata"}}
+	if !api_storage.FiltersMatchEntity(entity, f) {
+		t.Fatalf("expected eq match ignoring order")
+	}
+}
+
+func TestFiltersMatchEntityArrayNone(t *testing.T) {
+	entity := map[string]interface{}{"tags": []interface{}{"toto", "tata", "titi"}}
+	f := map[string]map[string]string{"tags": {"none": "tutu,tete"}}
+	if !api_storage.FiltersMatchEntity(entity, f) {
+		t.Fatalf("expected none match")
+	}
+	f = map[string]map[string]string{"tags": {"none": "tata,tete"}}
+	if api_storage.FiltersMatchEntity(entity, f) {
+		t.Fatalf("expected none fail")
+	}
+}
+
+func TestFiltersMatchEntityArrayMixedTypes(t *testing.T) {
+	entity := map[string]interface{}{"values": []interface{}{"1", 2.0, "three"}}
+	f := map[string]map[string]string{"values": {"contains": "1"}}
+	if !api_storage.FiltersMatchEntity(entity, f) {
+		t.Fatalf("expected contains match for stringified int")
+	}
+	f = map[string]map[string]string{"values": {"contains": "2"}}
+	if !api_storage.FiltersMatchEntity(entity, f) {
+		t.Fatalf("expected contains match for float")
+	}
+	f = map[string]map[string]string{"values": {"any": "two,three"}}
+	if !api_storage.FiltersMatchEntity(entity, f) {
+		t.Fatalf("expected any match for string value")
+	}
+	f = map[string]map[string]string{"values": {"none": "four,five"}}
+	if !api_storage.FiltersMatchEntity(entity, f) {
+		t.Fatalf("expected none match for absent values")
+	}
+}
+


### PR DESCRIPTION
This PR introduces advanced filtering support for array fields in ElysianDB's REST API. It includes new operators and comprehensive test coverage.

#### **Key Features:**

* Added support for array filter operators: `contains`, `not_contains`, `all`, `any`, `none`, and `eq`.
* Implemented mixed-type handling within arrays (e.g., strings, numbers).
* Added E2E and internal unit tests covering all new operations.
* Updated K6 benchmark script to include performance checks for array filters.
* Index cleanup was refactored to run asynchronously, ensuring efficient removal of entity IDs from all field indexes without blocking API operations.
* Optimization: Parallelized index construction in EnsureFieldIndex and UpdateIndexesForEntity using controlled concurrency for faster index rebuilding under load.

Closes https://github.com/elysiandb/elysiandb/issues/36