### PR TITLE
Lazy indexes for rest api

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,48 @@ const articles = await res.json();
 
 ---
 
+## ElysianDB Performance Summary
+
+**Instant REST API Benchmarks — Small Web Project Scenarios**
+
+ElysianDB demonstrates super real-time performance under realistic small-project workloads, maintaining sub-millisecond latency even under concurrent access.
+
+---
+
+### Benchmark Scenarios
+
+| Scenario             | Command                                                        | Description                                                  |
+| -------------------- | -------------------------------------------------------------- | ------------------------------------------------------------ |
+| **Dev Local**        | `BASE_URL=http://localhost:8089 KEYS=100 VUS=3 DURATION=10s`   | Light local usage — simulate developer / staging environment |
+| **Small Web App**    | `BASE_URL=http://localhost:8089 KEYS=500 VUS=10 DURATION=20s`  | Typical small production web app or SaaS dashboard           |
+| **Light Production** | `BASE_URL=http://localhost:8089 KEYS=1000 VUS=25 DURATION=30s` | Simulates modest real-world traffic with concurrent users    |
+
+---
+
+### Results Overview
+
+| Scenario             | Load               | p95 (Global) | Nested p95 | RPS    | HTTP Errors | Notes                          |
+| -------------------- | ------------------ | ------------ | ---------- | ------ | ----------- | ------------------------------ |
+| **Dev Local**        | 3 VUs / 100 keys   | **0.23 ms**  | 1.0 ms     | ~15k/s | 0 %         | Practically instantaneous      |
+| **Small Web App**    | 10 VUs / 500 keys  | **0.37 ms**  | 2.0 ms     | ~40k/s | 0 %         | Ultra-fluid API performance    |
+| **Light Production** | 25 VUs / 1000 keys | **1.35 ms**  | 14.7 ms    | ~41k/s | 0 %         | Stable at moderate concurrency |
+
+---
+
+### Key Takeaways
+
+**Sub-millisecond latency** for 95% of requests up to 10 concurrent users
+**Consistent <2 ms latency** under 25 concurrent users (hundreds of real users equivalent)
+**Zero errors** across all runs
+**Full coverage**: filtering, sorting, nested operations, and updates all included
+**Lazy indexing** remains transparent and cost-free under real-world usage
+
+---
+
+### Conclusion
+
+> **ElysianDB delivers true instant REST APIs — consistently under 2 ms at web-scale concurrency, with zero configuration and automatic indexing.**
+
 ## Highlights
 
 * **Fast in‑memory store** with shard routing (xxhash), optional TTL.

--- a/elysiandb.go
+++ b/elysiandb.go
@@ -15,15 +15,27 @@ import (
 	"github.com/taymour/elysiandb/internal/storage"
 )
 
+const (
+	reset  = "\033[0m"
+	bold   = "\033[1m"
+	faint  = "\033[2m"
+	gold   = "\033[38;5;220m"
+	blue   = "\033[38;5;27m"
+	violet = "\033[38;5;57m"
+	gray   = "\033[38;5;245m"
+)
+
+func banner() {
+	fmt.Printf("\n%s", blue)
+	fmt.Println(" ╔═══════════════════════════════════════════════════════════════════╗")
+	fmt.Printf(" ║ %s%-63s%s   ║\n", gold+bold, "ElysianDB", reset+blue)
+	fmt.Printf(" ║ %s%-63s%s   ║\n", gray, "A modern, lightweight KV datastore", reset+blue)
+	fmt.Printf(" ║ %s%-63s%s   ║\n", gold, "→ Instant REST API, out of the box", reset+blue)
+	fmt.Println(" ╚═══════════════════════════════════════════════════════════════════╝" + reset)
+}
+
 func main() {
-	fmt.Println(`
-   ╔══════════════════════════════════════╗
-   ║                                      ║
-   ║      Welcome to ElysianDB            ║
-   ║  A modern, lightweight KV datastore  ║
-   ║                                      ║
-   ╚══════════════════════════════════════╝
-	`)
+	banner()
 
 	configFilename := flag.String("config", "elysian.yaml", "Path to configuration file")
 	flag.Parse()
@@ -33,10 +45,9 @@ func main() {
 		log.Error("Error loading config:", err)
 		return
 	}
-
 	globals.SetConfig(cfg)
 
-	log.DirectInfo("Using data folder: ", globals.GetConfig().Store.Folder)
+	fmt.Printf("%s%sStorage%s  %s%s%s\n", violet, bold, reset, gray, globals.GetConfig().Store.Folder, reset)
 
 	if cfg.Stats.Enabled {
 		boot.BootStats()
@@ -44,24 +55,23 @@ func main() {
 
 	boot.InitDB()
 
-	log.DirectInfo("Ready to serve your key-value needs with elegance.")
+	fmt.Printf("%s%sReady%s   %sServing a KV datastore with %sInstant REST API%s.\n", blue, bold, reset, gray, gold, reset)
 
 	if cfg.Server.HTTP.Enabled {
 		go boot.StartHTTP()
+		fmt.Printf("%sHTTP%s     %shttp://%s:%d%s  %s(KV store & Instant REST API)%s\n",
+			gold, reset, bold, cfg.Server.HTTP.Host, cfg.Server.HTTP.Port, reset, gray, reset)
 	}
-
 	if cfg.Server.TCP.Enabled {
 		go boot.InitTCP()
+		fmt.Printf("%sTCP %s     %s%s:%d%s\n", gold, reset, bold, cfg.Server.TCP.Host, cfg.Server.TCP.Port, reset)
 	}
 
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
-
 	<-ctx.Done()
 
 	storage.WriteToDB()
-
-	log.DirectInfo("Data persisted successfully.")
-
-	log.DirectInfo("ElysianDB shutting down gracefully. Goodbye!")
+	fmt.Printf("\n%sPersisted%s  %sAll data flushed to disk.%s\n", gold, reset, gray, reset)
+	fmt.Printf("%sGoodbye%s   %sElysianDB shutting down gracefully.%s\n", blue, reset, faint, reset)
 }

--- a/internal/api/storage.go
+++ b/internal/api/storage.go
@@ -15,7 +15,7 @@ func WriteEntity(entity string, data map[string]interface{}) {
 	} else {
 		for k := range data {
 			if k != "id" {
-				EnsureFieldIndex(entity, k, data["id"].(string), data[k])
+				markFieldAndNestedDirty(entity, k, data[k])
 			}
 		}
 	}
@@ -81,6 +81,7 @@ func GetListOfIds(entity string, sortField string, sortAscending bool) ([]byte, 
 		idIndexKey := globals.ApiEntityIndexIdKey(entity)
 		return storage.GetByKey(idIndexKey)
 	}
+	ensureFieldIndexFresh(entity, sortField)
 	if !IndexExistsForField(entity, sortField) {
 		return []byte{}, nil
 	}

--- a/internal/boot/indexer.go
+++ b/internal/boot/indexer.go
@@ -1,0 +1,23 @@
+package boot
+
+import (
+	"time"
+
+	api_storage "github.com/taymour/elysiandb/internal/api"
+	"github.com/taymour/elysiandb/internal/globals"
+)
+
+func BootLazyIndexRebuilder() {
+	if globals.GetConfig().Server.HTTP.Enabled {
+		for i := 0; i < 8; i++ {
+			go rebuildDirtyIndexesWorker()
+		}
+	}
+}
+
+func rebuildDirtyIndexesWorker() {
+	for {
+		api_storage.ProcessNextDirtyField()
+		time.Sleep(100 * time.Millisecond)
+	}
+}

--- a/internal/boot/init.go
+++ b/internal/boot/init.go
@@ -31,4 +31,5 @@ func InitDB() {
 	BootExpirationHandler()
 	BootLogger()
 	BootApiCacheCleaner()
+	BootLazyIndexRebuilder()
 }

--- a/internal/configuration/loader.go
+++ b/internal/configuration/loader.go
@@ -66,7 +66,5 @@ func LoadConfig(path string) (*Config, error) {
 		return nil, err
 	}
 
-	fmt.Printf("Loaded config: %+v\n", cfg)
-
 	return &cfg, nil
 }


### PR DESCRIPTION
This PR introduces a lazy indexing mechanism to improve write performance for the REST API layer. Instead of rebuilding indexes synchronously on every create/update/delete operation, fields are now marked as *dirty* and rebuilt asynchronously by background workers.

#### Key changes:

* Added `DirtyFields` tracking with thread-safe `sync.Map`.
* Implemented `MarkFieldDirty`, `ensureFieldIndexFresh`, and `ProcessNextDirtyField` for lazy index rebuild.
* Added `BootLazyIndexRebuilder` with 8 background workers to process dirty indexes.
* Modified `UpdateIndexesForEntity`, `DeleteIndexesForField`, and related index operations to mark fields dirty instead of rebuilding immediately.
* Added unit tests for lazy rebuild and dirty flag handling.

#### Result:

Significant reduction in `create` and `update` latency (from ~1s to <100ms) while maintaining full data and index consistency.

Closes https://github.com/elysiandb/elysiandb/issues/55