### PR TITLE
Reworked api config and added index workers config

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,9 +85,12 @@ log:
   flushIntervalSeconds: 5
 stats:
   enabled: false
-apiCache:
-  enabled: true
-  cleanupIntervalSeconds: 10
+api:
+  index:
+    workers: 4
+  cache:
+    enabled: true
+    cleanupIntervalSeconds: 10
 
 ```
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -39,26 +39,30 @@ log:
   flushIntervalSeconds: 5
 stats:
   enabled: true
-apiCache:
-  enabled: true
-  cleanupIntervalSeconds: 10
+api:
+  index:
+    workers: 4
+  cache:
+    enabled: true
+    cleanupIntervalSeconds: 10
 ```
 
 ### Configuration Fields
 
-| Key                                 | Description                                            |
-| ----------------------------------- | ------------------------------------------------------ |
-| **store.folder**                    | Path where data is persisted to disk                   |
-| **store.shards**                    | Number of memory shards (must be a power of two)       |
-| **store.flushIntervalSeconds**      | Interval for automatic persistence to disk             |
-| **store.crashRecovery.enabled**     | Enables crash recovery logs for durability             |
-| **store.crashRecovery.maxLogMB**    | Maximum size of recovery logs before flush             |
-| **server.http**                     | Enables and configures the HTTP REST/KV interface      |
-| **server.tcp**                      | Enables and configures the TCP text protocol interface |
-| **log.flushIntervalSeconds**        | Interval for flushing in‑memory logs                   |
-| **stats.enabled**                   | Enables runtime metrics and `/stats` endpoint          |
-| **apiCache.enabled**                | Enables REST API caching for repeated queries          |
-| **apiCache.cleanupIntervalSeconds** | Interval for cache expiration cleanup                  |
+| Key                                  | Description                                            |
+| ------------------------------------ | ------------------------------------------------------ |
+| **store.folder**                     | Path where data is persisted to disk                   |
+| **store.shards**                     | Number of memory shards (must be a power of two)       |
+| **store.flushIntervalSeconds**       | Interval for automatic persistence to disk             |
+| **store.crashRecovery.enabled**      | Enables crash recovery logs for durability             |
+| **store.crashRecovery.maxLogMB**     | Maximum size of recovery logs before flush             |
+| **server.http**                      | Enables and configures the HTTP REST/KV interface      |
+| **server.tcp**                       | Enables and configures the TCP text protocol interface |
+| **log.flushIntervalSeconds**         | Interval for flushing in‑memory logs                   |
+| **stats.enabled**                    | Enables runtime metrics and `/stats` endpoint          |
+| **api.index.workers**                | Number of workers that rebuild dirty indexes           |
+| **api.cache.enabled**                | Enables REST API caching for repeated queries          |
+| **api.cache.cleanupIntervalSeconds** | Interval for cache expiration cleanup                  |
 
 ---
 

--- a/elysian.yaml
+++ b/elysian.yaml
@@ -10,6 +10,9 @@ log:
   flushIntervalSeconds: 5
 stats:
   enabled: false
-apiCache:
-  enabled: true
-  cleanupIntervalSeconds: 10
+api:
+  index:
+    workers: 4
+  cache:
+    enabled: true
+    cleanupIntervalSeconds: 10

--- a/internal/boot/cache.go
+++ b/internal/boot/cache.go
@@ -8,7 +8,7 @@ import (
 )
 
 func BootApiCacheCleaner() {
-	if globals.GetConfig().ApiCache.Enabled {
+	if globals.GetConfig().Api.Cache.Enabled {
 		go checkApiCachePeriodically()
 	}
 }

--- a/internal/boot/indexer.go
+++ b/internal/boot/indexer.go
@@ -11,7 +11,7 @@ func BootLazyIndexRebuilder() {
 	api_storage.RebuildAllIndexes()
 
 	if globals.GetConfig().Server.HTTP.Enabled {
-		for i := 0; i < 8; i++ {
+		for i := 0; i < globals.GetConfig().Api.Index.Workers; i++ {
 			go rebuildDirtyIndexesWorker()
 		}
 	}

--- a/internal/boot/init.go
+++ b/internal/boot/init.go
@@ -12,8 +12,8 @@ import (
 func InitDB() {
 	cfg := globals.GetConfig()
 
-	if cfg.ApiCache.Enabled {
-		cache.InitCache(time.Duration(cfg.ApiCache.CleanupIntervalSeconds) * time.Second)
+	if cfg.Api.Cache.Enabled {
+		cache.InitCache(time.Duration(cfg.Api.Cache.CleanupIntervalSeconds) * time.Second)
 	}
 
 	storage.LoadDB()

--- a/internal/configuration/loader.go
+++ b/internal/configuration/loader.go
@@ -9,11 +9,11 @@ import (
 )
 
 type Config struct {
-	Store    StoreConfig    `yaml:"store"`
-	Server   ServersConfig  `yaml:"server"`
-	Log      LogConfig      `yaml:"log"`
-	Stats    StatsConfig    `yaml:"stats"`
-	ApiCache ApiCacheConfig `yaml:"apiCache"`
+	Store  StoreConfig   `yaml:"store"`
+	Server ServersConfig `yaml:"server"`
+	Log    LogConfig     `yaml:"log"`
+	Stats  StatsConfig   `yaml:"stats"`
+	Api    ApiConfig     `yaml:"api"`
 }
 
 type ServersConfig struct {
@@ -45,6 +45,15 @@ type StoreConfig struct {
 
 type StatsConfig struct {
 	Enabled bool `yaml:"enabled"`
+}
+
+type ApiConfig struct {
+	Index ApiIndexConfig `yaml:"index"`
+	Cache ApiCacheConfig `yaml:"cache"`
+}
+
+type ApiIndexConfig struct {
+	Workers int `yaml:"workers"`
 }
 
 type ApiCacheConfig struct {

--- a/internal/transport/http/api/create.go
+++ b/internal/transport/http/api/create.go
@@ -37,7 +37,7 @@ func CreateController(ctx *fasthttp.RequestCtx) {
 	ctx.SetStatusCode(fasthttp.StatusOK)
 	ctx.SetBody(response)
 
-	if globals.GetConfig().ApiCache.Enabled {
+	if globals.GetConfig().Api.Cache.Enabled {
 		cache.CacheStore.Purge(entity)
 	}
 }

--- a/internal/transport/http/api/delete_by_id.go
+++ b/internal/transport/http/api/delete_by_id.go
@@ -14,7 +14,7 @@ func DeleteByIdController(ctx *fasthttp.RequestCtx) {
 
 	ctx.SetStatusCode(fasthttp.StatusNoContent)
 
-	if globals.GetConfig().ApiCache.Enabled {
+	if globals.GetConfig().Api.Cache.Enabled {
 		cache.CacheStore.Purge(entity)
 	}
 }

--- a/internal/transport/http/api/destroy.go
+++ b/internal/transport/http/api/destroy.go
@@ -13,7 +13,7 @@ func DestroyController(ctx *fasthttp.RequestCtx) {
 
 	ctx.SetStatusCode(fasthttp.StatusNoContent)
 
-	if globals.GetConfig().ApiCache.Enabled {
+	if globals.GetConfig().Api.Cache.Enabled {
 		cache.CacheStore.Purge(entity)
 	}
 }

--- a/internal/transport/http/api/get_by_id.go
+++ b/internal/transport/http/api/get_by_id.go
@@ -15,7 +15,7 @@ func GetByIdController(ctx *fasthttp.RequestCtx) {
 	fieldsParam := string(ctx.QueryArgs().Peek("fields"))
 	fields := api_storage.ParseFieldsParam(fieldsParam)
 
-	if len(fields) == 0 && globals.GetConfig().ApiCache.Enabled {
+	if len(fields) == 0 && globals.GetConfig().Api.Cache.Enabled {
 		if v := cache.CacheStore.GetById(entity, id); v != nil {
 			ctx.Response.Header.Set("Content-Type", "application/json")
 			ctx.SetStatusCode(fasthttp.StatusOK)
@@ -37,7 +37,7 @@ func GetByIdController(ctx *fasthttp.RequestCtx) {
 		return
 	}
 
-	if globals.GetConfig().ApiCache.Enabled {
+	if globals.GetConfig().Api.Cache.Enabled {
 		cache.CacheStore.SetById(entity, id, response)
 	}
 

--- a/internal/transport/http/api/list.go
+++ b/internal/transport/http/api/list.go
@@ -19,7 +19,7 @@ func ListController(ctx *fasthttp.RequestCtx) {
 	fieldsParam := string(ctx.QueryArgs().Peek("fields"))
 
 	var hash []byte
-	if globals.GetConfig().ApiCache.Enabled {
+	if globals.GetConfig().Api.Cache.Enabled {
 		hash = cache.HashQuery(entity, limit, offset, sortField, sortAscending, filters, fieldsParam)
 		cached := cache.CacheStore.Get(entity, hash)
 		if cached != nil {
@@ -53,7 +53,7 @@ func ListController(ctx *fasthttp.RequestCtx) {
 	ctx.SetStatusCode(fasthttp.StatusOK)
 	ctx.SetBody(response)
 
-	if globals.GetConfig().ApiCache.Enabled {
+	if globals.GetConfig().Api.Cache.Enabled {
 		cache.CacheStore.Set(entity, hash, response)
 	}
 }

--- a/internal/transport/http/api/update_by_id.go
+++ b/internal/transport/http/api/update_by_id.go
@@ -34,7 +34,7 @@ func UpdateByIdController(ctx *fasthttp.RequestCtx) {
 	ctx.SetStatusCode(fasthttp.StatusOK)
 	ctx.SetBody(response)
 
-	if globals.GetConfig().ApiCache.Enabled {
+	if globals.GetConfig().Api.Cache.Enabled {
 		cache.CacheStore.Purge(entity)
 	}
 }


### PR DESCRIPTION
Reworked API configuration and added index workers support

This update restructures the API configuration to group cache and index settings under a unified api section in the YAML file.
It also introduces the api.index.workers parameter to control the number of background workers rebuilding dirty indexes, improving flexibility and tuning for concurrent workloads.