### PR TITLE
Added create and update list of entities for rest api

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -74,10 +74,11 @@ ElysianDB automatically exposes REST endpoints per entity. Entities are inferred
 
 | Method   | Endpoint             | Description                                                 |
 | -------- | -------------------- | ----------------------------------------------------------- |
-| `POST`   | `/api/<entity>`      | Create a new JSON document (auto‑ID)                        |
+| `POST`   | `/api/<entity>`      | Create one or multiple JSON documents (auto‑ID if missing)  |
 | `GET`    | `/api/<entity>`      | List all documents, supports pagination, sorting, filtering |
 | `GET`    | `/api/<entity>/<id>` | Retrieve document by ID                                     |
-| `PUT`    | `/api/<entity>/<id>` | Update document fields                                      |
+| `PUT`    | `/api/<entity>/<id>` | Update a single document by ID                              |
+| `PUT`    | `/api/<entity>`      | Update multiple documents (batch update)                    |
 | `DELETE` | `/api/<entity>/<id>` | Delete document by ID                                       |
 | `DELETE` | `/api/<entity>`      | Delete all documents for an entity                          |
 
@@ -102,16 +103,26 @@ ElysianDB automatically exposes REST endpoints per entity. Entities are inferred
 | `any`          | Array includes any listed value        |
 | `none`         | Array excludes all listed values       |
 
-### Example
+### Examples
 
 ```bash
-# Create an entity
-curl -X POST http://localhost:8089/api/articles \
+# Create a single entity
+curl -X POST http://localhost:8089/api/users \
   -H 'Content-Type: application/json' \
-  -d '{"title": "Hello World", "tags": ["go", "db"], "published": true}'
+  -d '{"name": "Alice", "age": 30}'
+
+# Create multiple entities
+curl -X POST http://localhost:8089/api/users \
+  -H 'Content-Type: application/json' \
+  -d '[{"name": "Bob"}, {"name": "Charlie"}]'
+
+# Batch update entities
+curl -X PUT http://localhost:8089/api/users \
+  -H 'Content-Type: application/json' \
+  -d '[{"id": "u1", "age": 35}, {"id": "u2", "name": "Bobby"}]'
 
 # Query with filters and sorting
-curl "http://localhost:8089/api/articles?limit=10&offset=0&sort[title]=asc&filter[published][eq]=true"
+curl "http://localhost:8089/api/users?limit=10&offset=0&sort[name]=asc&filter[age][gt]=25"
 ```
 
 ---
@@ -238,8 +249,8 @@ Run performance benchmarks:
 
 ```bash
 make tcp_benchmark
-make http_benchmark # requires isntalling k6
-make api_benchmark # requires isntalling k6
+make http_benchmark # requires installing k6
+make api_benchmark # requires installing k6
 ```
 
 ---

--- a/internal/api/storage.go
+++ b/internal/api/storage.go
@@ -22,6 +22,12 @@ func WriteEntity(entity string, data map[string]interface{}) {
 	}
 }
 
+func WriteListOfEntities(entity string, list []map[string]interface{}) {
+	for _, data := range list {
+		WriteEntity(entity, data)
+	}
+}
+
 func AddEntityType(entity string) {
 	key := globals.ApiAllEntityTypesListKey()
 	data, _ := storage.GetByKey(key)
@@ -145,4 +151,19 @@ func UpdateEntityById(entity string, id string, updated map[string]interface{}) 
 	WriteEntity(entity, existing)
 	UpdateIndexesForEntity(entity, id, old, existing)
 	return existing
+}
+
+func UpdateListOfEntities(entity string, updates []map[string]interface{}) []map[string]interface{} {
+	results := make([]map[string]interface{}, 0, len(updates))
+	for _, upd := range updates {
+		id, ok := upd["id"].(string)
+		if !ok || id == "" {
+			continue
+		}
+		res := UpdateEntityById(entity, id, upd)
+		if res != nil {
+			results = append(results, res)
+		}
+	}
+	return results
 }

--- a/internal/routing/router.go
+++ b/internal/routing/router.go
@@ -27,6 +27,7 @@ func RegisterRoutes(r *router.Router) {
 	r.POST("/api/{entity}", api.CreateController)
 	r.GET("/api/{entity}/{id}", api.GetByIdController)
 	r.PUT("/api/{entity}/{id}", api.UpdateByIdController)
+	r.PUT("/api/{entity}", api.UpdateListController)
 	r.DELETE("/api/{entity}/{id}", api.DeleteByIdController)
 	r.DELETE("/api/{entity}", api.DestroyController)
 }


### PR DESCRIPTION
This PR adds support for batch creation and update of entities in the REST API.

- Added `WriteListOfEntities` and `UpdateListOfEntities` in storage layer  
- Extended API controllers to handle both single and list payloads  
- Updated routing to include `/api/{entity}` PUT endpoint  
- Added new end-to-end tests for batch create and update operations  

Closes #60
