### PR TITLE
Added basic schema validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@
 * **Multi‑Protocol** — HTTP, TCP (Redis-style text protocol), and Instant REST
 * **Automatic Indexing** — lazy-built indexes on first sort request
 * **Schema‑less JSON** — store any structure; IDs generated automatically
+* **Schema validation if enabled** — Inferred schema from POST and validate future POST
 * **Persistence** — automatic periodic flush and graceful shutdown
 
 ---

--- a/elysian.yaml
+++ b/elysian.yaml
@@ -11,6 +11,8 @@ log:
 stats:
   enabled: false
 api:
+  schema:
+    enabled: true
   index:
     workers: 4
   cache:

--- a/internal/configuration/loader.go
+++ b/internal/configuration/loader.go
@@ -47,9 +47,14 @@ type StatsConfig struct {
 	Enabled bool `yaml:"enabled"`
 }
 
+type ApiSchemaConfig struct {
+	Enabled bool `yaml:"enabled"`
+}
+
 type ApiConfig struct {
-	Index ApiIndexConfig `yaml:"index"`
-	Cache ApiCacheConfig `yaml:"cache"`
+	Index  ApiIndexConfig  `yaml:"index"`
+	Cache  ApiCacheConfig  `yaml:"cache"`
+	Schema ApiSchemaConfig `yaml:"schema"`
 }
 
 type ApiIndexConfig struct {

--- a/internal/schema/analyzer.go
+++ b/internal/schema/analyzer.go
@@ -1,0 +1,163 @@
+package schema
+
+import (
+	"fmt"
+	"reflect"
+
+	"github.com/taymour/elysiandb/internal/globals"
+	"github.com/taymour/elysiandb/internal/storage"
+)
+
+const SchemaEntity = "schema"
+
+var LoadSchemaForEntity = loadSchemaForEntity
+
+type Field struct {
+	Name   string
+	Type   string
+	Fields map[string]Field
+}
+
+type Entity struct {
+	ID     string
+	Fields map[string]Field
+}
+
+type ValidationError struct {
+	Field   string
+	Message string
+}
+
+func AnalyzeEntitySchema(entity string, data map[string]interface{}) map[string]interface{} {
+	schema := Entity{
+		ID:     entity,
+		Fields: analyzeFields(data),
+	}
+
+	return schemaEntityToStorableStructure(schema)
+}
+
+func ValidateEntity(entity string, data map[string]interface{}) []ValidationError {
+	var errors []ValidationError
+
+	schema := LoadSchemaForEntity(entity)
+	if schema == nil {
+		return errors
+	}
+
+	validateFieldsRecursive(schema.Fields, data, "", &errors)
+	return errors
+}
+
+func validateFieldsRecursive(fields map[string]Field, data map[string]interface{}, prefix string, errors *[]ValidationError) {
+	for fieldName, fieldDef := range fields {
+		fullName := fieldName
+		if prefix != "" {
+			fullName = prefix + "." + fieldName
+		}
+
+		value, exists := data[fieldName]
+		if !exists {
+			continue
+		}
+
+		t := reflect.TypeOf(value)
+		if t == nil {
+			*errors = append(*errors, ValidationError{
+				Field:   fullName,
+				Message: "nil value not allowed",
+			})
+			continue
+		}
+
+		typeName := t.String()
+		if typeName != fieldDef.Type {
+			*errors = append(*errors, ValidationError{
+				Field:   fullName,
+				Message: fmt.Sprintf("expected type %s but got %s", fieldDef.Type, typeName),
+			})
+			continue
+		}
+
+		if len(fieldDef.Fields) > 0 {
+			subMap, ok := value.(map[string]interface{})
+			if !ok {
+				*errors = append(*errors, ValidationError{
+					Field:   fullName,
+					Message: "expected nested object",
+				})
+				continue
+			}
+			validateFieldsRecursive(fieldDef.Fields, subMap, fullName, errors)
+		}
+	}
+}
+
+func analyzeFields(data map[string]interface{}) map[string]Field {
+	fields := make(map[string]Field)
+	for k, v := range data {
+		if k == "id" {
+			continue
+		}
+		t := reflect.TypeOf(v)
+		typeName := "unknown"
+		if t != nil {
+			typeName = t.String()
+		}
+		f := Field{Name: k, Type: typeName}
+		if sub, ok := v.(map[string]interface{}); ok {
+			f.Fields = analyzeFields(sub)
+		}
+		fields[k] = f
+	}
+	return fields
+}
+
+func schemaEntityToStorableStructure(entity Entity) map[string]interface{} {
+	result := make(map[string]interface{})
+	result["id"] = entity.ID
+	result["fields"] = fieldsToMap(entity.Fields)
+	return result
+}
+
+func fieldsToMap(fields map[string]Field) map[string]interface{} {
+	out := make(map[string]interface{})
+	for k, v := range fields {
+		fieldMap := map[string]interface{}{
+			"name": v.Name,
+			"type": v.Type,
+		}
+		if len(v.Fields) > 0 {
+			fieldMap["fields"] = fieldsToMap(v.Fields)
+		}
+		out[k] = fieldMap
+	}
+	return out
+}
+
+func mapToFields(m map[string]interface{}) map[string]Field {
+	fields := make(map[string]Field)
+	for k, v := range m {
+		if fieldMap, ok := v.(map[string]interface{}); ok {
+			f := Field{Name: k}
+			if typeName, ok := fieldMap["type"].(string); ok {
+				f.Type = typeName
+			}
+			if subFields, ok := fieldMap["fields"].(map[string]interface{}); ok {
+				f.Fields = mapToFields(subFields)
+			}
+			fields[k] = f
+		}
+	}
+	return fields
+}
+
+func loadSchemaForEntity(entity string) *Entity {
+	key := globals.ApiSingleEntityKey(SchemaEntity, entity)
+	data, _ := storage.GetJsonByKey(key)
+	schema := &Entity{ID: entity}
+	if fieldsMap, ok := data["fields"].(map[string]interface{}); ok {
+		schema.Fields = mapToFields(fieldsMap)
+	}
+	return schema
+}

--- a/test/internal/schema_test/analyzer_test.go
+++ b/test/internal/schema_test/analyzer_test.go
@@ -1,0 +1,140 @@
+package schema_test
+
+import (
+	"testing"
+
+	"github.com/taymour/elysiandb/internal/schema"
+)
+
+func patchLoadSchema(mock *schema.Entity) func() {
+	orig := schema.LoadSchemaForEntity
+	schema.LoadSchemaForEntity = func(entity string) *schema.Entity {
+		return mock
+	}
+	return func() {
+		schema.LoadSchemaForEntity = orig
+	}
+}
+
+func TestAnalyzeEntitySchema_Simple(t *testing.T) {
+	data := map[string]interface{}{
+		"id":   "u1",
+		"name": "Alice",
+		"age":  30,
+	}
+
+	result := schema.AnalyzeEntitySchema("users", data)
+
+	if result["id"] != "users" {
+		t.Fatalf("expected id=users, got %v", result["id"])
+	}
+
+	fields, ok := result["fields"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected fields map, got %T", result["fields"])
+	}
+
+	if fields["name"].(map[string]interface{})["type"] != "string" {
+		t.Fatalf("expected type string for name, got %v", fields["name"].(map[string]interface{})["type"])
+	}
+	if fields["age"].(map[string]interface{})["type"] != "int" {
+		t.Fatalf("expected type int for age, got %v", fields["age"].(map[string]interface{})["type"])
+	}
+}
+
+func TestAnalyzeEntitySchema_Nested(t *testing.T) {
+	data := map[string]interface{}{
+		"id":   "p1",
+		"name": "Post",
+		"author": map[string]interface{}{
+			"name": "John",
+			"age":  42,
+		},
+	}
+
+	result := schema.AnalyzeEntitySchema("posts", data)
+	fields := result["fields"].(map[string]interface{})
+	author := fields["author"].(map[string]interface{})
+	subFields := author["fields"].(map[string]interface{})
+
+	if subFields["name"].(map[string]interface{})["type"] != "string" {
+		t.Fatalf("expected nested field type string for author.name, got %v", subFields["name"].(map[string]interface{})["type"])
+	}
+	if subFields["age"].(map[string]interface{})["type"] != "int" {
+		t.Fatalf("expected nested field type int for author.age, got %v", subFields["age"].(map[string]interface{})["type"])
+	}
+}
+
+func TestValidateEntity_ValidData(t *testing.T) {
+	mockSchema := &schema.Entity{
+		ID: "users",
+		Fields: map[string]schema.Field{
+			"name": {Name: "name", Type: "string"},
+			"age":  {Name: "age", Type: "int"},
+		},
+	}
+	restore := patchLoadSchema(mockSchema)
+	defer restore()
+
+	data := map[string]interface{}{
+		"name": "Alice",
+		"age":  30,
+	}
+
+	errors := schema.ValidateEntity("users", data)
+	if len(errors) != 0 {
+		t.Fatalf("expected no validation errors, got %v", errors)
+	}
+}
+
+func TestValidateEntity_TypeMismatch(t *testing.T) {
+	mockSchema := &schema.Entity{
+		ID: "users",
+		Fields: map[string]schema.Field{
+			"name": {Name: "name", Type: "string"},
+			"age":  {Name: "age", Type: "int"},
+		},
+	}
+	restore := patchLoadSchema(mockSchema)
+	defer restore()
+
+	data := map[string]interface{}{
+		"name": 123,
+		"age":  "old",
+	}
+
+	errors := schema.ValidateEntity("users", data)
+	if len(errors) != 2 {
+		t.Fatalf("expected 2 validation errors, got %d", len(errors))
+	}
+}
+
+func TestValidateEntity_NestedMismatch(t *testing.T) {
+	mockSchema := &schema.Entity{
+		ID: "orders",
+		Fields: map[string]schema.Field{
+			"customer": {
+				Name: "customer",
+				Type: "map[string]interface {}",
+				Fields: map[string]schema.Field{
+					"name": {Name: "name", Type: "string"},
+					"age":  {Name: "age", Type: "int"},
+				},
+			},
+		},
+	}
+	restore := patchLoadSchema(mockSchema)
+	defer restore()
+
+	data := map[string]interface{}{
+		"customer": map[string]interface{}{
+			"name": 123,
+			"age":  "old",
+		},
+	}
+
+	errors := schema.ValidateEntity("orders", data)
+	if len(errors) != 2 {
+		t.Fatalf("expected 2 nested validation errors, got %d", len(errors))
+	}
+}


### PR DESCRIPTION
This update introduces an automatic schema analysis and validation system for the REST API.
ElysianDB now infers entity structures from the first insert and validates future writes against the stored schema — including nested fields.

* Schema validation can be toggled via api.schema.enabled.

* Invalid writes return structured validation errors.

* Includes unit and end-to-end tests for type safety and nested field consistency.

Closes https://github.com/elysiandb/elysiandb/issues/71