### PR TITLE
Added create sub-entities

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@
 * **Schema‑less JSON** — store any structure; IDs generated automatically
 * **Schema validation if enabled** — Inferred schema from POST and validate future POST
 * **Persistence** — automatic periodic flush and graceful shutdown
+* **Nested Entity Creation** — automatic creation and linking of sub-entities detected by @entity fields in JSON
 
 ---
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -85,6 +85,59 @@ ElysianDB automatically exposes REST endpoints per entity. Entities are inferred
 | `DELETE` | `/api/<entity>/<id>` | Delete document by ID                                       |
 | `DELETE` | `/api/<entity>`      | Delete all documents for an entity                          |
 
+### Nested Entity Creation (works the same way with update)
+
+ElysianDB supports creating entities that contain **sub-entities** within the same request. When a JSON object includes fields containing other objects with an `@entity` key, those sub-entities are automatically created, linked, and assigned unique IDs if missing.
+
+#### Example
+
+```bash
+curl -X POST http://localhost:8089/api/articles \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "title": "Nested Example",
+    "authors": [
+      {
+        "@entity": "author",
+        "fullname": "Mister T",
+        "status": "writer",
+        "job": {
+          "@entity": "job",
+          "id": "1234567890",
+          "designation": "Worker"
+        }
+      },
+      {
+        "@entity": "author",
+        "fullname": "Alberto",
+        "status": "coco",
+        "job": {
+          "@entity": "job",
+          "id": "1234567890"
+        }
+      }
+    ]
+  }'
+```
+
+This will create:
+
+* an `article` linked to two `author` entities
+* the `author` entities themselves, each linked to the same `job`
+* the `job` entity if it does not already exist
+
+ElysianDB automatically assigns IDs when missing and replaces nested objects with lightweight references of the form:
+
+```json
+{
+  "@entity": "author",
+  "id": "<uuid>"
+}
+```
+
+This mechanism also works recursively and supports **arrays of sub-entities**, allowing a document to include multiple nested or shared linked entities.
+
+
 ### Query Parameters
 
 * `limit` — Max number of items to return

--- a/internal/api/relationship.go
+++ b/internal/api/relationship.go
@@ -1,0 +1,106 @@
+package api_storage
+
+import (
+	"github.com/google/uuid"
+)
+
+func ExtractSubEntities(entity string, data map[string]interface{}) []map[string]interface{} {
+	var subs []map[string]interface{}
+	for k, v := range data {
+		switch val := v.(type) {
+		case map[string]interface{}:
+			subs = append(subs, handleMapSubEntity(entity, k, val, data)...)
+		case []interface{}:
+			subs = append(subs, handleArraySubEntities(entity, k, val, data)...)
+		}
+	}
+	return subs
+}
+
+func handleMapSubEntity(entity, key string, val, data map[string]interface{}) []map[string]interface{} {
+	var subs []map[string]interface{}
+	if subEntityName, ok := val["@entity"].(string); ok && subEntityName != "" {
+		id, realFields := extractIDAndCheckFields(val)
+		if !realFields && id != "" {
+			data[key] = map[string]interface{}{"@entity": subEntityName, "id": id}
+			return subs
+		}
+		sub := buildSubEntity(subEntityName, id, val)
+		data[key] = map[string]interface{}{"@entity": subEntityName, "id": id}
+		deeper := ExtractSubEntities(subEntityName, sub)
+		if len(deeper) > 0 {
+			subs = append(subs, deeper...)
+		}
+		subs = append(subs, sub)
+	} else {
+		deeper := ExtractSubEntities(entity, val)
+		if len(deeper) > 0 {
+			subs = append(subs, deeper...)
+		}
+		data[key] = val
+	}
+	return subs
+}
+
+func handleArraySubEntities(entity, key string, arr []interface{}, data map[string]interface{}) []map[string]interface{} {
+	var subs []map[string]interface{}
+	newArr := make([]interface{}, len(arr))
+	for i, item := range arr {
+		if m, ok := item.(map[string]interface{}); ok {
+			newArr[i], subs = processArrayItem(entity, m, subs)
+		} else {
+			newArr[i] = item
+		}
+	}
+	data[key] = newArr
+	return subs
+}
+
+func processArrayItem(entity string, m map[string]interface{}, subs []map[string]interface{}) (interface{}, []map[string]interface{}) {
+	if subEntityName, ok := m["@entity"].(string); ok && subEntityName != "" {
+		id, _ := extractIDAndCheckFields(m)
+		sub := buildSubEntity(subEntityName, id, m)
+		link := map[string]interface{}{"@entity": subEntityName, "id": id}
+		deeper := ExtractSubEntities(subEntityName, sub)
+		if len(deeper) > 0 {
+			subs = append(subs, deeper...)
+		}
+		subs = append(subs, sub)
+		return link, subs
+	}
+	deeper := ExtractSubEntities(entity, m)
+	if len(deeper) > 0 {
+		subs = append(subs, deeper...)
+	}
+	return m, subs
+}
+
+func extractIDAndCheckFields(val map[string]interface{}) (string, bool) {
+	var curID string
+	if s, ok := val["id"].(string); ok && s != "" {
+		curID = s
+	} else if s, ok := val["@id"].(string); ok && s != "" {
+		curID = s
+	}
+	realFields := false
+	for subKey := range val {
+		if subKey != "@entity" && subKey != "id" && subKey != "@id" {
+			realFields = true
+			break
+		}
+	}
+	if curID == "" {
+		curID = uuid.New().String()
+	}
+	return curID, realFields
+}
+
+func buildSubEntity(subEntityName, id string, val map[string]interface{}) map[string]interface{} {
+	sub := map[string]interface{}{"id": id, "@entity": subEntityName}
+	for subKey, subVal := range val {
+		if subKey != "@entity" && subKey != "id" && subKey != "@id" {
+			sub[subKey] = subVal
+		}
+	}
+	return sub
+}

--- a/test/internal/api_test/relationship_test.go
+++ b/test/internal/api_test/relationship_test.go
@@ -1,0 +1,141 @@
+package api_test
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/google/uuid"
+	api_storage "github.com/taymour/elysiandb/internal/api"
+)
+
+func TestExtractSubEntitiesSimple(t *testing.T) {
+	data := map[string]interface{}{
+		"name": "youyou",
+		"author": map[string]interface{}{
+			"@entity":  "author",
+			"fullname": "Taymour",
+		},
+	}
+	subs := api_storage.ExtractSubEntities("article", data)
+	if len(subs) != 1 {
+		t.Fatalf("expected 1 sub entity, got %d", len(subs))
+	}
+	if subs[0]["@entity"] != "author" {
+		t.Fatalf("expected sub entity 'author', got %v", subs[0]["@entity"])
+	}
+	if _, ok := subs[0]["id"].(string); !ok {
+		t.Fatalf("expected id field in sub entity")
+	}
+	a := data["author"].(map[string]interface{})
+	if a["@entity"] != "author" {
+		t.Fatalf("expected author link to have @entity")
+	}
+	if _, ok := a["id"].(string); !ok {
+		t.Fatalf("expected author link to have id")
+	}
+}
+
+func TestExtractSubEntitiesNested(t *testing.T) {
+	data := map[string]interface{}{
+		"name": "youyou",
+		"author": map[string]interface{}{
+			"@entity":  "author",
+			"fullname": "Taymour Negib",
+			"status":   "writer",
+			"job": map[string]interface{}{
+				"@entity":     "job",
+				"designation": "Worker",
+			},
+		},
+	}
+	subs := api_storage.ExtractSubEntities("article", data)
+	if len(subs) != 2 {
+		t.Fatalf("expected 2 sub entities, got %d", len(subs))
+	}
+	var author map[string]interface{}
+	var job map[string]interface{}
+	for _, s := range subs {
+		if s["@entity"] == "author" {
+			author = s
+		}
+		if s["@entity"] == "job" {
+			job = s
+		}
+	}
+	if author == nil || job == nil {
+		t.Fatalf("missing author or job in subs")
+	}
+	if job["designation"] != "Worker" {
+		t.Fatalf("expected job.designation=Worker, got %v", job["designation"])
+	}
+	if reflect.TypeOf(author["job"]).Kind() != reflect.Map {
+		t.Fatalf("expected author.job to be a map")
+	}
+	j := author["job"].(map[string]interface{})
+	if j["@entity"] != "job" {
+		t.Fatalf("expected author.job.@entity=job, got %v", j["@entity"])
+	}
+	if _, err := uuid.Parse(j["id"].(string)); err != nil {
+		t.Fatalf("expected valid uuid for job.id")
+	}
+}
+
+func TestExtractSubEntitiesArray(t *testing.T) {
+	data := map[string]interface{}{
+		"name":  "youyou",
+		"age":   13,
+		"title": "this is it",
+		"authors": []interface{}{
+			map[string]interface{}{
+				"@entity":  "author",
+				"fullname": "Taymour Negib",
+				"status":   "writer",
+				"job": map[string]interface{}{
+					"@entity":     "job",
+					"designation": "Worker",
+				},
+			},
+			map[string]interface{}{
+				"@entity":  "author",
+				"fullname": "Alberto",
+				"status":   "coco",
+			},
+		},
+	}
+	subs := api_storage.ExtractSubEntities("article", data)
+	if len(subs) != 3 {
+		t.Fatalf("expected 3 sub entities (2 authors + 1 job), got %d", len(subs))
+	}
+	var authors []map[string]interface{}
+	var job map[string]interface{}
+	for _, s := range subs {
+		if s["@entity"] == "author" {
+			authors = append(authors, s)
+		}
+		if s["@entity"] == "job" {
+			job = s
+		}
+	}
+	if len(authors) != 2 {
+		t.Fatalf("expected 2 authors, got %d", len(authors))
+	}
+	if job == nil {
+		t.Fatalf("missing job in subs")
+	}
+	if job["designation"] != "Worker" {
+		t.Fatalf("expected job.designation=Worker, got %v", job["designation"])
+	}
+	arr := data["authors"].([]interface{})
+	if len(arr) != 2 {
+		t.Fatalf("expected 2 author links, got %d", len(arr))
+	}
+	for _, a := range arr {
+		m := a.(map[string]interface{})
+		if m["@entity"] != "author" {
+			t.Fatalf("expected @entity=author, got %v", m["@entity"])
+		}
+		if _, err := uuid.Parse(m["id"].(string)); err != nil {
+			t.Fatalf("expected valid uuid for author.id")
+		}
+	}
+}


### PR DESCRIPTION
This PR adds automatic creation and linking of sub-entities in ElysianDB. Entities containing objects marked with `@entity` are now created recursively with unique IDs and stored as linked entities.

Includes updates to `WriteEntity`, new recursive logic in `relationship.go`, and unit tests verifying nested and array-based entity creation.


Closes https://github.com/elysiandb/elysiandb/issues/68