### PR TITLE
api rest read with includes & filters on includes

### DIFF
--- a/internal/api/include.go
+++ b/internal/api/include.go
@@ -1,0 +1,119 @@
+package api_storage
+
+import "strings"
+
+var ReadEntityByIdFunc = ReadEntityById
+
+func ApplyIncludes(data []map[string]interface{}, includesParam string) []map[string]interface{} {
+	allMode := strings.TrimSpace(includesParam) == "all"
+	includeTree := buildIncludeTree(includesParam, allMode)
+	for _, entityData := range data {
+		applyIncludesRecursive(entityData, includeTree, allMode)
+	}
+	return data
+}
+
+func buildIncludeTree(includesParam string, allMode bool) map[string][]string {
+	includeTree := make(map[string][]string)
+	if allMode {
+		return includeTree
+	}
+	includes := strings.Split(includesParam, ",")
+	for _, inc := range includes {
+		parts := strings.SplitN(strings.TrimSpace(inc), ".", 2)
+		if len(parts) == 1 {
+			includeTree[parts[0]] = append(includeTree[parts[0]], "")
+		} else {
+			includeTree[parts[0]] = append(includeTree[parts[0]], parts[1])
+		}
+	}
+	return includeTree
+}
+
+func applyIncludesRecursive(entityData map[string]interface{}, tree map[string][]string, forceAll bool) {
+	fields := collectIncludeFields(entityData, tree, forceAll)
+	for _, field := range fields {
+		val, ok := entityData[field]
+		if !ok || val == nil {
+			continue
+		}
+		switch v := val.(type) {
+		case map[string]interface{}:
+			entityData[field] = includeSingleEntity(v)
+			next := buildNextTree(tree[field], forceAll)
+			if m, ok := entityData[field].(map[string]interface{}); ok {
+				applyIncludesRecursive(m, next, forceAll)
+			}
+		case []interface{}:
+			newList := []map[string]interface{}{}
+			for _, item := range v {
+				if m, ok := item.(map[string]interface{}); ok {
+					m = includeSingleEntity(m)
+					next := buildNextTree(tree[field], forceAll)
+					applyIncludesRecursive(m, next, forceAll)
+					newList = append(newList, m)
+				}
+			}
+			entityData[field] = newList
+		}
+	}
+}
+
+func collectIncludeFields(entityData map[string]interface{}, tree map[string][]string, forceAll bool) []string {
+	fields := []string{}
+	if forceAll {
+		for k, v := range entityData {
+			switch val := v.(type) {
+			case map[string]interface{}:
+				if _, ok := val["@entity"]; ok {
+					fields = append(fields, k)
+				}
+			case []interface{}:
+				for _, item := range val {
+					if m, ok := item.(map[string]interface{}); ok {
+						if _, ok2 := m["@entity"]; ok2 {
+							fields = append(fields, k)
+							break
+						}
+					}
+				}
+			}
+		}
+	} else {
+		for k := range tree {
+			fields = append(fields, k)
+		}
+	}
+	return fields
+}
+
+func includeSingleEntity(m map[string]interface{}) map[string]interface{} {
+	if ent, ok := m["@entity"].(string); ok {
+		if id, ok := m["id"].(string); ok && id != "" {
+			read := ReadEntityByIdFunc(ent, id)
+			if read != nil {
+				read["@entity"] = ent
+				return read
+			}
+		}
+	}
+	return m
+}
+
+func buildNextTree(subs []string, forceAll bool) map[string][]string {
+	if forceAll {
+		return map[string][]string{}
+	}
+	next := map[string][]string{}
+	for _, sub := range subs {
+		if sub != "" {
+			parts := strings.SplitN(sub, ".", 2)
+			if len(parts) == 1 {
+				next[parts[0]] = append(next[parts[0]], "")
+			} else {
+				next[parts[0]] = append(next[parts[0]], parts[1])
+			}
+		}
+	}
+	return next
+}

--- a/internal/api/sort.go
+++ b/internal/api/sort.go
@@ -36,7 +36,7 @@ func parseDateForSort(s string) (time.Time, bool) {
 }
 
 func GetSortedEntityIdsByField(entity string, field string, ascending bool) []string {
-	data := ListEntities(entity, 0, 0, "", ascending, map[string]map[string]string{})
+	data := ListEntities(entity, 0, 0, "", ascending, map[string]map[string]string{}, "all")
 
 	sort.Slice(data, func(i, j int) bool {
 		a := getSortNestedValue(data[i], field)

--- a/internal/api/storage.go
+++ b/internal/api/storage.go
@@ -100,6 +100,7 @@ func ListEntities(
 	sortField string,
 	sortAscending bool,
 	filters map[string]map[string]string,
+	includesParam string,
 ) []map[string]interface{} {
 	idList, err := GetListOfIds(entity, sortField, sortAscending)
 	if err != nil {
@@ -112,14 +113,20 @@ func ListEntities(
 	if len(filters) == 0 {
 		ids = applyOffsetLimit(ids, offset, limit)
 	}
-	filtered := make([]map[string]interface{}, 0, len(ids))
+	all := make([]map[string]interface{}, 0, len(ids))
 	for _, id := range ids {
 		entityData := ReadEntityById(entity, id)
 		if entityData != nil {
-			if !FiltersMatchEntity(entityData, filters) {
-				continue
-			}
-			filtered = append(filtered, entityData)
+			all = append(all, entityData)
+		}
+	}
+	if includesParam != "" {
+		all = ApplyIncludes(all, includesParam)
+	}
+	filtered := make([]map[string]interface{}, 0, len(all))
+	for _, e := range all {
+		if FiltersMatchEntity(e, filters) {
+			filtered = append(filtered, e)
 		}
 	}
 	if len(filters) > 0 {

--- a/internal/cache/cache.go
+++ b/internal/cache/cache.go
@@ -114,13 +114,24 @@ func (s *cacheStore) Purge(entity string) {
 	s.mu.Unlock()
 }
 
-func HashQuery(entity string, limit, offset int, sortField string, sortAscending bool, filters map[string]map[string]string, fieldsParam string) []byte {
+func HashQuery(
+	entity string,
+	limit int,
+	offset int,
+	sortField string,
+	sortAscending bool,
+	filters map[string]map[string]string,
+	fieldsParam string,
+	includesParam string,
+) []byte {
 	var b []byte
 	b = append(b, entity...)
 	b = append(b, '|')
 	b = append(b, sortField...)
 	b = append(b, '|')
 	b = append(b, fieldsParam...)
+	b = append(b, '|')
+	b = append(b, includesParam...)
 	b = append(b, '|')
 	if sortAscending {
 		b = append(b, 'A')

--- a/internal/transport/http/api/get_by_id.go
+++ b/internal/transport/http/api/get_by_id.go
@@ -14,6 +14,7 @@ func GetByIdController(ctx *fasthttp.RequestCtx) {
 	id := ctx.UserValue("id").(string)
 	fieldsParam := string(ctx.QueryArgs().Peek("fields"))
 	fields := api_storage.ParseFieldsParam(fieldsParam)
+	includesParam := string(ctx.QueryArgs().Peek("includes"))
 
 	if len(fields) == 0 && globals.GetConfig().Api.Cache.Enabled {
 		if v := cache.CacheStore.GetById(entity, id); v != nil {
@@ -25,6 +26,10 @@ func GetByIdController(ctx *fasthttp.RequestCtx) {
 	}
 
 	data := api_storage.ReadEntityById(entity, id)
+	if data != nil && includesParam != "" {
+		list := []map[string]interface{}{data}
+		data = api_storage.ApplyIncludes(list, includesParam)[0]
+	}
 
 	if len(fields) > 0 {
 		data = api_storage.FilterFields(data, fields)

--- a/internal/transport/http/api/list.go
+++ b/internal/transport/http/api/list.go
@@ -17,10 +17,11 @@ func ListController(ctx *fasthttp.RequestCtx) {
 	sortField, sortAscending := ParseSortParam(ctx.QueryArgs())
 	filters := ParseFilterParam(ctx.QueryArgs())
 	fieldsParam := string(ctx.QueryArgs().Peek("fields"))
+	includesParam := string(ctx.QueryArgs().Peek("includes"))
 
 	var hash []byte
 	if globals.GetConfig().Api.Cache.Enabled {
-		hash = cache.HashQuery(entity, limit, offset, sortField, sortAscending, filters, fieldsParam)
+		hash = cache.HashQuery(entity, limit, offset, sortField, sortAscending, filters, fieldsParam, includesParam)
 		cached := cache.CacheStore.Get(entity, hash)
 		if cached != nil {
 			ctx.Response.Header.Set("Content-Type", "application/json")
@@ -30,7 +31,7 @@ func ListController(ctx *fasthttp.RequestCtx) {
 		}
 	}
 
-	data := api_storage.ListEntities(entity, limit, offset, sortField, sortAscending, filters)
+	data := api_storage.ListEntities(entity, limit, offset, sortField, sortAscending, filters, includesParam)
 
 	fields := api_storage.ParseFieldsParam(fieldsParam)
 	if len(fields) > 0 {

--- a/test/internal/api_test/include_test.go
+++ b/test/internal/api_test/include_test.go
@@ -1,0 +1,196 @@
+package api_test
+
+import (
+	"reflect"
+	"testing"
+
+	api_storage "github.com/taymour/elysiandb/internal/api"
+)
+
+var store = map[string]map[string]interface{}{
+	"category:e6a49734": {"id": "e6a49734", "type": "gogo", "@entity": "category"},
+	"job:1234567890":    {"id": "1234567890", "designation": "Worker", "@entity": "job"},
+	"author:32e1f608": {
+		"id":       "32e1f608",
+		"fullname": "Taymour Negib",
+		"status":   "writer",
+		"job": map[string]interface{}{
+			"@entity": "job",
+			"id":      "1234567890",
+		},
+		"@entity": "author",
+	},
+	"author:25667686": {
+		"id":       "25667686",
+		"fullname": "Alberto",
+		"status":   "coco",
+		"job": map[string]interface{}{
+			"@entity": "job",
+			"id":      "1234567890",
+		},
+		"@entity": "author",
+	},
+}
+
+func mockReadEntityById(entity string, id string) map[string]interface{} {
+	key := entity + ":" + id
+	if v, ok := store[key]; ok {
+		return v
+	}
+	if len(id) > 8 {
+		key = entity + ":" + id[:8]
+		if v, ok := store[key]; ok {
+			return v
+		}
+	}
+	return nil
+}
+
+func init() {
+	api_storage.ReadEntityByIdFunc = mockReadEntityById
+}
+
+func normalizeAuthors(raw interface{}) []map[string]interface{} {
+	if raw == nil {
+		return nil
+	}
+	switch v := raw.(type) {
+	case []interface{}:
+		out := make([]map[string]interface{}, 0, len(v))
+		for _, el := range v {
+			if m, ok := el.(map[string]interface{}); ok {
+				out = append(out, m)
+			}
+		}
+		return out
+	case []map[string]interface{}:
+		return v
+	default:
+		return nil
+	}
+}
+
+func TestApplyIncludes_SimpleInclude(t *testing.T) {
+	data := []map[string]interface{}{
+		{
+			"id":   "d5a3e752",
+			"name": "youyou",
+			"category": map[string]interface{}{
+				"@entity": "category",
+				"id":      "e6a49734",
+			},
+		},
+	}
+	result := api_storage.ApplyIncludes(data, "category")
+	category, ok := result[0]["category"].(map[string]interface{})
+	if !ok || category["type"] != "gogo" || category["@entity"] != "category" {
+		t.Fatalf("unexpected category: %+v", category)
+	}
+}
+
+func TestApplyIncludes_MultipleIncludes(t *testing.T) {
+	data := []map[string]interface{}{
+		{
+			"id":   "d5a3e752",
+			"name": "youyou",
+			"category": map[string]interface{}{
+				"@entity": "category",
+				"id":      "e6a49734",
+			},
+			"authors": []interface{}{
+				map[string]interface{}{
+					"@entity": "author",
+					"id":      "32e1f608",
+				},
+				map[string]interface{}{
+					"@entity": "author",
+					"id":      "25667686",
+				},
+			},
+		},
+	}
+	result := api_storage.ApplyIncludes(data, "category,authors,authors.job")
+	entity := result[0]
+	cat := entity["category"].(map[string]interface{})
+	if cat["type"] != "gogo" {
+		t.Fatalf("category not included properly: %+v", cat)
+	}
+	authors := normalizeAuthors(entity["authors"])
+	if len(authors) != 2 {
+		t.Fatalf("unexpected authors length: %d", len(authors))
+	}
+	for _, a := range authors {
+		if a["fullname"] == nil {
+			t.Fatalf("author not loaded: %+v", a)
+		}
+		job, ok := a["job"].(map[string]interface{})
+		if !ok || job["designation"] != "Worker" {
+			t.Fatalf("job not loaded properly: %+v", job)
+		}
+	}
+}
+
+func TestApplyIncludes_AllMode(t *testing.T) {
+	data := []map[string]interface{}{
+		{
+			"id":   "test1",
+			"name": "entity1",
+			"category": map[string]interface{}{
+				"@entity": "category",
+				"id":      "e6a49734",
+			},
+			"authors": []interface{}{
+				map[string]interface{}{
+					"@entity": "author",
+					"id":      "32e1f608",
+				},
+			},
+		},
+	}
+	result := api_storage.ApplyIncludes(data, "all")
+	entity := result[0]
+	cat := entity["category"].(map[string]interface{})
+	if cat["type"] != "gogo" {
+		t.Fatalf("category not included in all mode: %+v", cat)
+	}
+	authors := normalizeAuthors(entity["authors"])
+	if len(authors) == 0 {
+		t.Fatalf("authors not included in all mode: %+v", entity["authors"])
+	}
+	a := authors[0]
+	if a["fullname"] != "Taymour Negib" {
+		t.Fatalf("author not included in all mode: %+v", a)
+	}
+	job := a["job"].(map[string]interface{})
+	if job["designation"] != "Worker" {
+		t.Fatalf("nested job not included in all mode: %+v", job)
+	}
+}
+
+func TestApplyIncludes_EmptyInclude(t *testing.T) {
+	data := []map[string]interface{}{
+		{"id": "1", "name": "simple"},
+	}
+	result := api_storage.ApplyIncludes(data, "")
+	if !reflect.DeepEqual(result, data) {
+		t.Fatalf("expected unchanged data, got %+v", result)
+	}
+}
+
+func TestApplyIncludes_MissingRelations(t *testing.T) {
+	data := []map[string]interface{}{
+		{
+			"id":   "x",
+			"name": "test",
+			"unknown": map[string]interface{}{
+				"@entity": "missing",
+				"id":      "000",
+			},
+		},
+	}
+	result := api_storage.ApplyIncludes(data, "unknown")
+	val := result[0]["unknown"].(map[string]interface{})
+	if val["@entity"] != "missing" {
+		t.Fatalf("unexpected missing entity behavior: %+v", val)
+	}
+}

--- a/test/internal/api_test/storage_test.go
+++ b/test/internal/api_test/storage_test.go
@@ -63,7 +63,7 @@ func TestReadAllEntities(t *testing.T) {
 	api_storage.WriteEntity(entity, u1)
 	api_storage.WriteEntity(entity, u2)
 
-	all := api_storage.ListEntities(entity, 0, 0, "", true, nil)
+	all := api_storage.ListEntities(entity, 0, 0, "", true, nil, "")
 	if len(all) != 2 {
 		t.Fatalf("ListEntities len=%d, want 2, all=%v", len(all), all)
 	}
@@ -133,7 +133,7 @@ func TestDeleteAllEntities_RemovesAllForThatEntityOnly(t *testing.T) {
 
 	api_storage.DeleteAllEntities("posts")
 
-	if list := api_storage.ListEntities("posts", 0, 0, "", true, nil); len(list) != 0 {
+	if list := api_storage.ListEntities("posts", 0, 0, "", true, nil, ""); len(list) != 0 {
 		t.Fatalf("posts should be empty, got %v", list)
 	}
 	if v := api_storage.ReadEntityById("profiles", "me"); v == nil {
@@ -167,7 +167,7 @@ func TestListEntities_WithFilters(t *testing.T) {
 	api_storage.WriteEntity(entity, map[string]interface{}{"id": "b3", "title": "Advanced Go", "author": "Alice"})
 
 	filters := map[string]map[string]string{"author": {"eq": "Alice"}}
-	results := api_storage.ListEntities(entity, 0, 0, "", true, filters)
+	results := api_storage.ListEntities(entity, 0, 0, "", true, filters, "")
 	if len(results) != 2 {
 		t.Fatalf("expected 2 results for author=Alice, got %d (%v)", len(results), results)
 	}
@@ -180,13 +180,13 @@ func TestListEntities_WithFilters(t *testing.T) {
 	}
 
 	filters = map[string]map[string]string{"title": {"eq": "Learning Python"}}
-	results = api_storage.ListEntities(entity, 0, 0, "", true, filters)
+	results = api_storage.ListEntities(entity, 0, 0, "", true, filters, "")
 	if len(results) != 1 || results[0]["id"] != "b2" {
 		t.Fatalf("expected only b2, got %v", results)
 	}
 
 	filters = map[string]map[string]string{"author": {"eq": "Al*"}}
-	results = api_storage.ListEntities(entity, 0, 0, "", true, filters)
+	results = api_storage.ListEntities(entity, 0, 0, "", true, filters, "")
 	if len(results) != 2 {
 		t.Fatalf("expected 2 results for author wildcard, got %d (%v)", len(results), results)
 	}
@@ -199,7 +199,7 @@ func TestListEntities_WithFilters(t *testing.T) {
 	}
 
 	filters = map[string]map[string]string{"title": {"eq": "*Go*"}}
-	results = api_storage.ListEntities(entity, 0, 0, "", true, filters)
+	results = api_storage.ListEntities(entity, 0, 0, "", true, filters, "")
 	if len(results) != 2 {
 		t.Fatalf("expected 2 results for title contains Go, got %d (%v)", len(results), results)
 	}
@@ -212,7 +212,7 @@ func TestListEntities_WithFilters(t *testing.T) {
 	}
 
 	filters = map[string]map[string]string{"author": {"neq": "Alice"}}
-	results = api_storage.ListEntities(entity, 0, 0, "", true, filters)
+	results = api_storage.ListEntities(entity, 0, 0, "", true, filters, "")
 	if len(results) != 1 || results[0]["id"] != "b2" {
 		t.Fatalf("expected only b2 with neq filter, got %v", results)
 	}
@@ -257,19 +257,19 @@ func TestListEntities_WithNestedFilters(t *testing.T) {
 	})
 
 	f1 := map[string]map[string]string{"author.name": {"eq": "Alice"}}
-	r1 := api_storage.ListEntities(entity, 0, 0, "", true, f1)
+	r1 := api_storage.ListEntities(entity, 0, 0, "", true, f1, "")
 	if len(r1) != 1 || r1[0]["id"] != "a2" {
 		t.Fatalf("expected only a2, got %v", r1)
 	}
 
 	f2 := map[string]map[string]string{"author.name": {"eq": "mister*"}}
-	r2 := api_storage.ListEntities(entity, 0, 0, "", true, f2)
+	r2 := api_storage.ListEntities(entity, 0, 0, "", true, f2, "")
 	if len(r2) != 1 || r2[0]["id"] != "a1" {
 		t.Fatalf("expected only a1 (case-insensitive, wildcard), got %v", r2)
 	}
 
 	f3 := map[string]map[string]string{"author.category.title": {"eq": "yep"}}
-	r3 := api_storage.ListEntities(entity, 0, 0, "", true, f3)
+	r3 := api_storage.ListEntities(entity, 0, 0, "", true, f3, "")
 	if len(r3) != 2 {
 		t.Fatalf("expected a1 and a3 for category=yep, got %v", r3)
 	}
@@ -282,7 +282,7 @@ func TestListEntities_WithNestedFilters(t *testing.T) {
 		"author.category.title": {"eq": "yep"},
 		"author.name":           {"neq": "bob"},
 	}
-	r4 := api_storage.ListEntities(entity, 0, 0, "", true, f4)
+	r4 := api_storage.ListEntities(entity, 0, 0, "", true, f4, "")
 	if len(r4) != 1 || r4[0]["id"] != "a1" {
 		t.Fatalf("expected only a1 for combined eq/neq, got %v", r4)
 	}
@@ -297,37 +297,37 @@ func TestListEntities_WithNumericFilters(t *testing.T) {
 	api_storage.WriteEntity(entity, map[string]interface{}{"id": "p3", "price": float64(30)})
 
 	f1 := map[string]map[string]string{"price": {"eq": "20"}}
-	r1 := api_storage.ListEntities(entity, 0, 0, "", true, f1)
+	r1 := api_storage.ListEntities(entity, 0, 0, "", true, f1, "")
 	if len(r1) != 1 || r1[0]["id"] != "p2" {
 		t.Fatalf("expected only p2 for eq=20, got %v", r1)
 	}
 
 	f2 := map[string]map[string]string{"price": {"neq": "20"}}
-	r2 := api_storage.ListEntities(entity, 0, 0, "", true, f2)
+	r2 := api_storage.ListEntities(entity, 0, 0, "", true, f2, "")
 	if len(r2) != 2 {
 		t.Fatalf("expected 2 results for neq=20, got %v", r2)
 	}
 
 	f3 := map[string]map[string]string{"price": {"lt": "20"}}
-	r3 := api_storage.ListEntities(entity, 0, 0, "", true, f3)
+	r3 := api_storage.ListEntities(entity, 0, 0, "", true, f3, "")
 	if len(r3) != 1 || r3[0]["id"] != "p1" {
 		t.Fatalf("expected only p1 for lt=20, got %v", r3)
 	}
 
 	f4 := map[string]map[string]string{"price": {"lte": "20"}}
-	r4 := api_storage.ListEntities(entity, 0, 0, "", true, f4)
+	r4 := api_storage.ListEntities(entity, 0, 0, "", true, f4, "")
 	if len(r4) != 2 {
 		t.Fatalf("expected p1 and p2 for lte=20, got %v", r4)
 	}
 
 	f5 := map[string]map[string]string{"price": {"gt": "20"}}
-	r5 := api_storage.ListEntities(entity, 0, 0, "", true, f5)
+	r5 := api_storage.ListEntities(entity, 0, 0, "", true, f5, "")
 	if len(r5) != 1 || r5[0]["id"] != "p3" {
 		t.Fatalf("expected only p3 for gt=20, got %v", r5)
 	}
 
 	f6 := map[string]map[string]string{"price": {"gte": "20"}}
-	r6 := api_storage.ListEntities(entity, 0, 0, "", true, f6)
+	r6 := api_storage.ListEntities(entity, 0, 0, "", true, f6, "")
 	if len(r6) != 2 {
 		t.Fatalf("expected p2 and p3 for gte=20, got %v", r6)
 	}

--- a/test/internal/cache_test/cache_test.go
+++ b/test/internal/cache_test/cache_test.go
@@ -10,7 +10,7 @@ import (
 func TestCacheSetGet(t *testing.T) {
 	cache.InitCache(10 * time.Second)
 	entity := "users"
-	hash := cache.HashQuery("users", 10, 0, "name", true, nil, "")
+	hash := cache.HashQuery("users", 10, 0, "name", true, nil, "", "")
 	value := []byte(`{"id":"1","name":"Alice"}`)
 	cache.CacheStore.Set(entity, hash, value)
 	got := cache.CacheStore.Get(entity, hash)
@@ -22,7 +22,7 @@ func TestCacheSetGet(t *testing.T) {
 func TestCacheGetNotExist(t *testing.T) {
 	cache.InitCache(10 * time.Second)
 	entity := "users"
-	hash := cache.HashQuery("users", 10, 0, "name", true, nil, "")
+	hash := cache.HashQuery("users", 10, 0, "name", true, nil, "", "")
 	got := cache.CacheStore.Get(entity, hash)
 	if got != nil {
 		t.Fatalf("expected nil, got %s", got)
@@ -42,7 +42,7 @@ func TestCacheInvalidHashLength(t *testing.T) {
 func TestCachePurge(t *testing.T) {
 	cache.InitCache(10 * time.Second)
 	entity := "users"
-	hash := cache.HashQuery("users", 10, 0, "name", true, nil, "")
+	hash := cache.HashQuery("users", 10, 0, "name", true, nil, "", "")
 	value := []byte(`{"id":"1"}`)
 	cache.CacheStore.Set(entity, hash, value)
 	cache.CacheStore.Purge(entity)
@@ -53,20 +53,20 @@ func TestCachePurge(t *testing.T) {
 }
 
 func TestHashQueryDifferentInputs(t *testing.T) {
-	h1 := cache.HashQuery("users", 10, 0, "name", true, nil, "")
-	h2 := cache.HashQuery("users", 20, 0, "name", true, nil, "")
+	h1 := cache.HashQuery("users", 10, 0, "name", true, nil, "", "")
+	h2 := cache.HashQuery("users", 20, 0, "name", true, nil, "", "")
 	if string(h1) == string(h2) {
 		t.Fatalf("expected different hashes for different limits")
 	}
-	h3 := cache.HashQuery("users", 10, 5, "name", true, nil, "")
+	h3 := cache.HashQuery("users", 10, 5, "name", true, nil, "", "")
 	if string(h1) == string(h3) {
 		t.Fatalf("expected different hashes for different offsets")
 	}
-	h4 := cache.HashQuery("users", 10, 0, "name", false, nil, "")
+	h4 := cache.HashQuery("users", 10, 0, "name", false, nil, "", "")
 	if string(h1) == string(h4) {
 		t.Fatalf("expected different hashes for ascending vs descending")
 	}
-	h5 := cache.HashQuery("users", 10, 0, "age", true, nil, "")
+	h5 := cache.HashQuery("users", 10, 0, "age", true, nil, "", "")
 	if string(h1) == string(h5) {
 		t.Fatalf("expected different hashes for different sort fields")
 	}
@@ -82,9 +82,9 @@ func TestHashQueryWithFiltersStringOps(t *testing.T) {
 	f3 := map[string]map[string]string{
 		"name": {"eq": "Bob"},
 	}
-	h1 := cache.HashQuery("users", 10, 0, "name", true, f1, "")
-	h2 := cache.HashQuery("users", 10, 0, "name", true, f2, "")
-	h3 := cache.HashQuery("users", 10, 0, "name", true, f3, "")
+	h1 := cache.HashQuery("users", 10, 0, "name", true, f1, "", "")
+	h2 := cache.HashQuery("users", 10, 0, "name", true, f2, "", "")
+	h3 := cache.HashQuery("users", 10, 0, "name", true, f3, "", "")
 	if string(h1) == string(h2) {
 		t.Fatalf("expected different hashes for eq vs neq")
 	}
@@ -106,10 +106,10 @@ func TestHashQueryWithFiltersNumericOps(t *testing.T) {
 	f4 := map[string]map[string]string{
 		"age": {"gte": "30"},
 	}
-	h1 := cache.HashQuery("users", 10, 0, "age", true, f1, "")
-	h2 := cache.HashQuery("users", 10, 0, "age", true, f2, "")
-	h3 := cache.HashQuery("users", 10, 0, "age", true, f3, "")
-	h4 := cache.HashQuery("users", 10, 0, "age", true, f4, "")
+	h1 := cache.HashQuery("users", 10, 0, "age", true, f1, "", "")
+	h2 := cache.HashQuery("users", 10, 0, "age", true, f2, "", "")
+	h3 := cache.HashQuery("users", 10, 0, "age", true, f3, "", "")
+	h4 := cache.HashQuery("users", 10, 0, "age", true, f4, "", "")
 	if string(h1) == string(h2) {
 		t.Fatalf("expected different hashes for lt vs lte")
 	}
@@ -130,8 +130,8 @@ func TestHashQueryWithMultipleFilters(t *testing.T) {
 		"name": {"eq": "Alice"},
 		"age":  {"gte": "30"},
 	}
-	h1 := cache.HashQuery("users", 10, 0, "name", true, f1, "")
-	h2 := cache.HashQuery("users", 10, 0, "name", true, f2, "")
+	h1 := cache.HashQuery("users", 10, 0, "name", true, f1, "", "")
+	h2 := cache.HashQuery("users", 10, 0, "name", true, f2, "", "")
 	if string(h1) == string(h2) {
 		t.Fatalf("expected different hashes for different filter values on age")
 	}
@@ -144,17 +144,17 @@ func TestHashQueryWithNestedFilters(t *testing.T) {
 	f2 := map[string]map[string]string{
 		"profile.age": {"lt": "40"},
 	}
-	h1 := cache.HashQuery("users", 10, 0, "profile.name", true, f1, "")
-	h2 := cache.HashQuery("users", 10, 0, "profile.age", true, f2, "")
+	h1 := cache.HashQuery("users", 10, 0, "profile.name", true, f1, "", "")
+	h2 := cache.HashQuery("users", 10, 0, "profile.age", true, f2, "", "")
 	if string(h1) == string(h2) {
 		t.Fatalf("expected different hashes for nested filters with different fields")
 	}
 }
 
 func TestHashQueryWithNestedSort(t *testing.T) {
-	h1 := cache.HashQuery("users", 10, 0, "profile.name", true, nil, "")
-	h2 := cache.HashQuery("users", 10, 0, "profile.name", false, nil, "")
-	h3 := cache.HashQuery("users", 10, 0, "profile.age", true, nil, "")
+	h1 := cache.HashQuery("users", 10, 0, "profile.name", true, nil, "", "")
+	h2 := cache.HashQuery("users", 10, 0, "profile.name", false, nil, "", "")
+	h3 := cache.HashQuery("users", 10, 0, "profile.age", true, nil, "", "")
 	if string(h1) == string(h2) {
 		t.Fatalf("expected different hashes for asc vs desc on nested field")
 	}
@@ -166,7 +166,7 @@ func TestHashQueryWithNestedSort(t *testing.T) {
 func TestCacheExpiration(t *testing.T) {
 	cache.InitCache(100 * time.Millisecond)
 	entity := "users"
-	hash := cache.HashQuery("users", 10, 0, "name", true, nil, "")
+	hash := cache.HashQuery("users", 10, 0, "name", true, nil, "", "")
 	value := []byte(`{"id":"1","name":"Alice"}`)
 	cache.CacheStore.Set(entity, hash, value)
 	time.Sleep(200 * time.Millisecond)
@@ -216,7 +216,7 @@ func TestCacheExpirationById(t *testing.T) {
 func TestCacheCleanExpiredRemovesBothDataAndIds(t *testing.T) {
 	cache.InitCache(10 * time.Millisecond)
 	entity := "users"
-	hash := cache.HashQuery("users", 10, 0, "name", true, nil, "")
+	hash := cache.HashQuery("users", 10, 0, "name", true, nil, "", "")
 	cache.CacheStore.Set(entity, hash, []byte("val"))
 	cache.CacheStore.SetById(entity, "id1", []byte("val"))
 	time.Sleep(20 * time.Millisecond)


### PR DESCRIPTION
This update enables relationship expansion and nested filtering for ElysianDB.

* Added `includes` support to `GET /api/:entity` and `GET /api/:entity/:id`.
* Supports deep includes (e.g. `includes=author,author.job`) and `includes=all`.
* Allows filters on nested fields (e.g. `filter[author.job.designation][eq]=Writer`).
* Allow sort on nested fields
* Updated caching and tests accordingly.

Example:

```bash
curl "http://localhost:8089/api/articles/123?includes=author,author.job"
```

Closes https://github.com/elysiandb/elysiandb/issues/74
Closes https://github.com/elysiandb/elysiandb/issues/73
Closes https://github.com/elysiandb/elysiandb/issues/75