### PR TITLE
Rest api import/export dump

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -84,6 +84,8 @@ ElysianDB automatically exposes REST endpoints per entity. Entities are inferred
 | `PUT`    | `/api/<entity>`      | Update multiple documents (batch update)                    |
 | `DELETE` | `/api/<entity>/<id>` | Delete document by ID                                       |
 | `DELETE` | `/api/<entity>`      | Delete all documents for an entity                          |
+| `GET`    | `/api/export`        | Dumps all entities as a JSON object                         |
+| `GET`    | `/api/import`        | Imports all objects from a JSON dump                        |
 
 ### Nested Entity Creation (works the same way with update)
 

--- a/internal/routing/router.go
+++ b/internal/routing/router.go
@@ -23,6 +23,8 @@ func RegisterRoutes(r *router.Router) {
 		r.GET("/stats", controller.StatsController)
 	}
 
+	r.GET("/api/export", api.ExportController)
+	r.GET("/api/import", api.ImportController)
 	r.GET("/api/{entity}", api.ListController)
 	r.POST("/api/{entity}", api.CreateController)
 	r.GET("/api/{entity}/{id}", api.GetByIdController)

--- a/internal/transport/http/api/export.go
+++ b/internal/transport/http/api/export.go
@@ -1,0 +1,22 @@
+package api
+
+import (
+	"encoding/json"
+
+	api_storage "github.com/taymour/elysiandb/internal/api"
+	"github.com/valyala/fasthttp"
+)
+
+func ExportController(ctx *fasthttp.RequestCtx) {
+	ctx.Response.Header.Set("Content-Type", "application/json")
+	ctx.SetStatusCode(fasthttp.StatusOK)
+
+	response, err := json.Marshal(api_storage.DumpAll())
+	if err != nil {
+		ctx.SetStatusCode(fasthttp.StatusInternalServerError)
+		ctx.SetBody([]byte(`{"error":"failed to marshal response"}`))
+		return
+	}
+
+	ctx.SetBody(response)
+}

--- a/internal/transport/http/api/import.go
+++ b/internal/transport/http/api/import.go
@@ -1,0 +1,24 @@
+package api
+
+import (
+	"encoding/json"
+
+	api_storage "github.com/taymour/elysiandb/internal/api"
+	"github.com/valyala/fasthttp"
+)
+
+func ImportController(ctx *fasthttp.RequestCtx) {
+	ctx.Response.Header.Set("Content-Type", "application/json")
+
+	var dump map[string][]map[string]interface{}
+	if err := json.Unmarshal(ctx.PostBody(), &dump); err != nil {
+		ctx.SetStatusCode(fasthttp.StatusBadRequest)
+		ctx.SetBody([]byte(`{"error":"invalid JSON dump"}`))
+		return
+	}
+
+	api_storage.ImportAll(dump)
+
+	ctx.SetStatusCode(fasthttp.StatusOK)
+	ctx.SetBody([]byte(`{"status":"import completed"}`))
+}


### PR DESCRIPTION
This PR introduces two new REST endpoints to export and import the entire ElysianDB dataset as JSON. The feature allows users to easily back up and restore their database contents.

**Endpoints:**

* `GET /api/export` — Dumps all entities as a JSON object.
* `POST /api/import` — Restores all entities from a provided JSON dump.


Closes https://github.com/elysiandb/elysiandb/issues/79