### PR TITLE
Added migrations for rest api

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@
 * **Schema validation if enabled** — Inferred schema from POST and validate future POST
 * **Persistence** — automatic periodic flush and graceful shutdown
 * **Nested Entity Creation** — automatic creation and linking of sub-entities detected by @entity fields in JSON
+* **Migrations** — perform global updates via /api/<entity>/migrate endpoint with declarative actions like set
 
 ---
 

--- a/internal/api/migration.go
+++ b/internal/api/migration.go
@@ -1,0 +1,90 @@
+package api_storage
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/taymour/elysiandb/internal/log"
+)
+
+type MigrationQuery struct {
+	Entity     string
+	Action     string
+	Properties map[string]any
+}
+
+const ACTION_SET = "set"
+
+func ParseMigrationQuery(s string, entity string) []MigrationQuery {
+	var rawItems []map[string]json.RawMessage
+	if err := json.Unmarshal([]byte(s), &rawItems); err != nil {
+		return nil
+	}
+
+	out := make([]MigrationQuery, 0, len(rawItems))
+	for _, item := range rawItems {
+		for action, payload := range item {
+			var propsList []map[string]any
+			if err := json.Unmarshal(payload, &propsList); err == nil {
+				for _, props := range propsList {
+					out = append(out, MigrationQuery{
+						Entity:     entity,
+						Action:     action,
+						Properties: props,
+					})
+				}
+				continue
+			}
+
+			var props map[string]any
+			if err := json.Unmarshal(payload, &props); err == nil {
+				out = append(out, MigrationQuery{
+					Entity:     entity,
+					Action:     action,
+					Properties: props,
+				})
+			}
+		}
+	}
+
+	return out
+}
+
+func ExecuteMigrations(migrationQueries []MigrationQuery) error {
+	for _, query := range migrationQueries {
+		switch query.Action {
+		case ACTION_SET:
+			log.Info("Executing migration set action on entity:", query.Entity)
+			executeMigrationSetAction(query.Entity, query.Properties)
+		default:
+			return fmt.Errorf("unsupported action: %s", query.Action)
+		}
+	}
+
+	return nil
+}
+
+func executeMigrationSetAction(entity string, properties map[string]any) error {
+	entities := ListEntities(entity, 0, 0, "", true, map[string]map[string]string{}, "all")
+
+	for _, ent := range entities {
+		for key, value := range properties {
+			SetNestedField(ent, key, value)
+		}
+
+		id, _ := ent["id"].(string)
+		if id == "" {
+			if v, ok := ent["_id"].(string); ok {
+				id = v
+			}
+		}
+
+		if id == "" {
+			return fmt.Errorf("missing id")
+		}
+
+		UpdateEntityById(entity, id, ent)
+	}
+
+	return nil
+}

--- a/internal/api/storage.go
+++ b/internal/api/storage.go
@@ -85,6 +85,16 @@ func AddEntityType(entity string) {
 	}
 }
 
+func EntityTypeExists(entity string) bool {
+	for _, t := range ListEntityTypes() {
+		if t == entity {
+			return true
+		}
+	}
+
+	return false
+}
+
 func ListEntityTypes() []string {
 	data, _ := storage.GetByKey(globals.ApiAllEntityTypesListKey())
 	return decodeIDs(data)

--- a/internal/routing/router.go
+++ b/internal/routing/router.go
@@ -32,4 +32,5 @@ func RegisterRoutes(r *router.Router) {
 	r.PUT("/api/{entity}", api.UpdateListController)
 	r.DELETE("/api/{entity}/{id}", api.DeleteByIdController)
 	r.DELETE("/api/{entity}", api.DestroyController)
+	r.POST("/api/{entity}/migrate", api.MigrateController)
 }

--- a/internal/transport/http/api/migrate.go
+++ b/internal/transport/http/api/migrate.go
@@ -1,0 +1,38 @@
+package api
+
+import (
+	"fmt"
+
+	api_storage "github.com/taymour/elysiandb/internal/api"
+	"github.com/valyala/fasthttp"
+)
+
+func MigrateController(ctx *fasthttp.RequestCtx) {
+	ctx.Response.Header.Set("Content-Type", "application/json")
+
+	entity := ctx.UserValue("entity").(string)
+
+	if !api_storage.EntityTypeExists(entity) {
+		ctx.SetStatusCode(fasthttp.StatusNotFound)
+		ctx.SetBodyString(fmt.Sprintf(`{"error" : "Entity '%s' does not exist."}`, entity))
+
+		return
+	}
+
+	migrationQueries := api_storage.ParseMigrationQuery(string(ctx.PostBody()), entity)
+
+	if len(migrationQueries) == 0 {
+		ctx.SetStatusCode(fasthttp.StatusBadRequest)
+		ctx.SetBodyString(`{"error" : "No valid migration queries found in the request body."}`)
+		return
+	}
+
+	if err := api_storage.ExecuteMigrations(migrationQueries); err != nil {
+		ctx.SetStatusCode(fasthttp.StatusBadRequest)
+		ctx.SetBodyString(fmt.Sprintf(`{"error" : "Migration failed: %s"}`, err.Error()))
+		return
+	}
+
+	ctx.SetStatusCode(fasthttp.StatusOK)
+	ctx.SetBodyString(fmt.Sprintf(`{"message" : "Entity '%s' migrated successfully."}`, entity))
+}

--- a/test/internal/api_test/migration_test.go
+++ b/test/internal/api_test/migration_test.go
@@ -1,0 +1,59 @@
+package api_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	api_storage "github.com/taymour/elysiandb/internal/api"
+)
+
+func TestParseMigrationQuery_SingleSet(t *testing.T) {
+	body := `[{"set": [{"name": "test"}]}]`
+	result := api_storage.ParseMigrationQuery(body, "users")
+
+	if len(result) != 1 {
+		t.Fatalf("expected 1 query, got %d", len(result))
+	}
+
+	q := result[0]
+	if q.Entity != "users" {
+		t.Errorf("expected entity 'users', got %s", q.Entity)
+	}
+	if q.Action != "set" {
+		t.Errorf("expected action 'set', got %s", q.Action)
+	}
+	if q.Properties["name"] != "test" {
+		t.Errorf("expected property name 'test', got %v", q.Properties["name"])
+	}
+}
+
+func TestParseMigrationQuery_InvalidJSON(t *testing.T) {
+	body := `invalid json`
+	result := api_storage.ParseMigrationQuery(body, "users")
+	if result != nil {
+		t.Errorf("expected nil for invalid JSON")
+	}
+}
+
+func TestExecuteMigrations_UnsupportedAction(t *testing.T) {
+	q := []api_storage.MigrationQuery{
+		{Entity: "users", Action: "unknown", Properties: map[string]any{"name": "x"}},
+	}
+	err := api_storage.ExecuteMigrations(q)
+	if err == nil {
+		t.Errorf("expected error for unsupported action")
+	}
+}
+
+func TestParseMigrationQuery_ObjectSyntax(t *testing.T) {
+	obj := map[string]any{"set": map[string]any{"age": 30}}
+	raw, _ := json.Marshal([]any{obj})
+	result := api_storage.ParseMigrationQuery(string(raw), "users")
+
+	if len(result) != 1 {
+		t.Fatalf("expected 1 query, got %d", len(result))
+	}
+	if result[0].Properties["age"] != float64(30) {
+		t.Errorf("expected property age 30, got %v", result[0].Properties["age"])
+	}
+}


### PR DESCRIPTION
This pull request introduces support for performing data migrations via the REST API. It includes a new `/api/{entity}/migrate` endpoint that enables applying `set` actions on all existing records of an entity. The implementation supports nested field updates using dot notation.


Closes https://github.com/elysiandb/elysiandb/issues/66