### PR TITLE
Added get schema for entity

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,8 @@ stats:
 api:
   index:
     workers: 4
+  schema:
+    enabled: true
   cache:
     enabled: true
     cleanupIntervalSeconds: 10
@@ -108,6 +110,7 @@ api:
 * `GET    /api/<entity>/<id>` → Read
 * `PUT    /api/<entity>/<id>` → Update
 * `DELETE /api/<entity>/<id>` → Delete
+* `GET    /api/<entity>/schema` → Schema for entity (if config api.schema is enabled)
 
 ### **TCP (Redis-style)**
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,7 +8,7 @@ This document explains how to use ElysianDB, its features, configuration, and ru
 
 ## Overview
 
-ElysianDB lets you store and query data instantly — without defining schemas or models.
+ElysianDB lets you store and query data instantly — with or without defining schemas or models.
 
 You can:
 
@@ -81,6 +81,7 @@ For some requests, there is a `X-Elysian-Cache` header with values : `HIT` or `M
 | -------- | ----------------------- | ----------------------------------------------------------- |
 | `POST`   | `/api/<entity>`         | Create one or multiple JSON documents (auto‑ID if missing)  |
 | `GET`    | `/api/<entity>`         | List all documents, supports pagination, sorting, filtering |
+| `GET`    | `/api/<entity>/schema`  | Schema for entity                                           |
 | `GET`    | `/api/<entity>/<id>`    | Retrieve document by ID                                     |
 | `PUT`    | `/api/<entity>/<id>`    | Update a single document by ID                              |
 | `PUT`    | `/api/<entity>`         | Update multiple documents (batch update)                    |
@@ -89,6 +90,68 @@ For some requests, there is a `X-Elysian-Cache` header with values : `HIT` or `M
 | `GET`    | `/api/export`           | Dumps all entities as a JSON object                         |
 | `POST`   | `/api/import`           | Imports all objects from a JSON dump                        |
 | `POST`   | `/api/<entity>/migrate` | Run a **migration** across all documents for an entity      |
+
+---
+
+## Schema API
+
+ElysianDB now infers schemas automatically and exposes them through a simple endpoint. This helps understand your data structure instantly, without configuration.
+
+---
+
+### How It Works
+
+* When you insert or update `/api/<entity>`, ElysianDB analyzes the JSON.
+* It detects: strings, numbers, booleans, objects, arrays.
+* It stores the inferred structure under the special entity `schema/<entity>`.
+
+Example input:
+
+```json
+{"title":"Example","author":{"name":"Alice"},"tags":["go"]}
+```
+
+Becomes:
+
+```json
+{
+    "fields": {
+        "author": {
+            "fields": {
+                "name": {
+                    "name": "name",
+                    "type": "string"
+                }
+            },
+            "name": "author",
+            "type": "object"
+        },
+        "tags": {
+            "name": "tags",
+            "type": "array"
+        },
+        "title": {
+            "name": "title",
+            "type": "string"
+        }
+    },
+    "id": "article"
+}
+```
+
+---
+
+### Endpoint
+
+#### `GET /api/<entity>/schema`
+
+Returns the current schema inferred from existing documents.
+
+If no documents exist yet:
+
+```json
+{"error":"schema not found"}
+```
 
 ---
 

--- a/internal/api/storage.go
+++ b/internal/api/storage.go
@@ -31,6 +31,7 @@ func WriteEntity(entity string, data map[string]interface{}) []schema.Validation
 
 	persistEntity(entity, data)
 	updateSchemaIfNeeded(entity, data)
+
 	return []schema.ValidationError{}
 }
 
@@ -41,6 +42,7 @@ func persistEntity(entity string, data map[string]interface{}) {
 	storage.PutJsonValue(key, data)
 	AddIdToindexes(entity, id)
 	AddEntityType(entity)
+
 	if old != nil {
 		UpdateIndexesForEntity(entity, id, old, data)
 	} else {

--- a/internal/routing/router.go
+++ b/internal/routing/router.go
@@ -34,6 +34,10 @@ func RegisterRoutes(r *router.Router) {
 	r.DELETE("/api/{entity}/{id}", Version(api.DeleteByIdController))
 	r.DELETE("/api/{entity}", Version(api.DestroyController))
 	r.POST("/api/{entity}/migrate", Version(api.MigrateController))
+
+	if globals.GetConfig().Api.Schema.Enabled {
+		r.GET("/api/{entity}/schema", Version(api.GetSchemaController))
+	}
 }
 
 func Version(requestHandler fasthttp.RequestHandler) fasthttp.RequestHandler {

--- a/internal/schema/analyzer.go
+++ b/internal/schema/analyzer.go
@@ -31,10 +31,64 @@ type ValidationError struct {
 func AnalyzeEntitySchema(entity string, data map[string]interface{}) map[string]interface{} {
 	schema := Entity{
 		ID:     entity,
-		Fields: analyzeFields(data),
+		Fields: analyzeFields(data, true),
 	}
 
 	return schemaEntityToStorableStructure(schema)
+}
+
+func analyzeFields(data map[string]interface{}, isRoot bool) map[string]Field {
+	fields := make(map[string]Field)
+
+	for k, v := range data {
+		if isRoot && k == "id" {
+			continue
+		}
+
+		f := Field{Name: k}
+		typeName := detectJSONType(v)
+		f.Type = typeName
+
+		switch typeName {
+
+		case "object":
+			sub, _ := v.(map[string]interface{})
+			f.Fields = analyzeFields(sub, false)
+
+		case "array":
+			arr := v.([]interface{})
+			if len(arr) > 0 {
+				if firstObj, ok := arr[0].(map[string]interface{}); ok {
+					f.Fields = analyzeFields(firstObj, false)
+				}
+			}
+		}
+
+		fields[k] = f
+	}
+
+	return fields
+}
+
+func detectJSONType(v interface{}) string {
+	switch val := v.(type) {
+	case string:
+		return "string"
+	case float64, float32, int, int64, uint64, uint:
+		return "number"
+	case bool:
+		return "boolean"
+	case map[string]interface{}:
+		return "object"
+	case []interface{}:
+		return "array"
+	default:
+		if val != nil {
+			return reflect.TypeOf(val).String()
+		}
+
+		return "unknown"
+	}
 }
 
 func ValidateEntity(entity string, data map[string]interface{}) []ValidationError {
@@ -51,6 +105,7 @@ func ValidateEntity(entity string, data map[string]interface{}) []ValidationErro
 
 func validateFieldsRecursive(fields map[string]Field, data map[string]interface{}, prefix string, errors *[]ValidationError) {
 	for fieldName, fieldDef := range fields {
+
 		fullName := fieldName
 		if prefix != "" {
 			fullName = prefix + "." + fieldName
@@ -61,63 +116,56 @@ func validateFieldsRecursive(fields map[string]Field, data map[string]interface{
 			continue
 		}
 
-		t := reflect.TypeOf(value)
-		if t == nil {
+		expected := fieldDef.Type
+		actual := detectJSONType(value)
+
+		if actual != expected {
 			*errors = append(*errors, ValidationError{
 				Field:   fullName,
-				Message: "nil value not allowed",
+				Message: fmt.Sprintf("expected type %s but got %s", expected, actual),
 			})
+
 			continue
 		}
 
-		typeName := t.String()
-		if typeName != fieldDef.Type {
-			*errors = append(*errors, ValidationError{
-				Field:   fullName,
-				Message: fmt.Sprintf("expected type %s but got %s", fieldDef.Type, typeName),
-			})
-			continue
-		}
-
-		if len(fieldDef.Fields) > 0 {
-			subMap, ok := value.(map[string]interface{})
+		if expected == "object" {
+			sub, ok := value.(map[string]interface{})
 			if !ok {
 				*errors = append(*errors, ValidationError{
 					Field:   fullName,
-					Message: "expected nested object",
+					Message: "expected object",
 				})
 				continue
 			}
-			validateFieldsRecursive(fieldDef.Fields, subMap, fullName, errors)
+			validateFieldsRecursive(fieldDef.Fields, sub, fullName, errors)
 		}
-	}
-}
 
-func analyzeFields(data map[string]interface{}) map[string]Field {
-	fields := make(map[string]Field)
-	for k, v := range data {
-		if k == "id" {
-			continue
+		if expected == "array" {
+			arr, ok := value.([]interface{})
+			if !ok {
+				*errors = append(*errors, ValidationError{
+					Field:   fullName,
+					Message: "expected array",
+				})
+				continue
+			}
+
+			if len(fieldDef.Fields) > 0 {
+				for i, item := range arr {
+					if obj, ok := item.(map[string]interface{}); ok {
+						validateFieldsRecursive(fieldDef.Fields, obj, fmt.Sprintf("%s[%d]", fullName, i), errors)
+					}
+				}
+			}
 		}
-		t := reflect.TypeOf(v)
-		typeName := "unknown"
-		if t != nil {
-			typeName = t.String()
-		}
-		f := Field{Name: k, Type: typeName}
-		if sub, ok := v.(map[string]interface{}); ok {
-			f.Fields = analyzeFields(sub)
-		}
-		fields[k] = f
 	}
-	return fields
 }
 
 func schemaEntityToStorableStructure(entity Entity) map[string]interface{} {
-	result := make(map[string]interface{})
-	result["id"] = entity.ID
-	result["fields"] = fieldsToMap(entity.Fields)
-	return result
+	return map[string]interface{}{
+		"id":     entity.ID,
+		"fields": fieldsToMap(entity.Fields),
+	}
 }
 
 func fieldsToMap(fields map[string]Field) map[string]interface{} {
@@ -127,11 +175,14 @@ func fieldsToMap(fields map[string]Field) map[string]interface{} {
 			"name": v.Name,
 			"type": v.Type,
 		}
+
 		if len(v.Fields) > 0 {
 			fieldMap["fields"] = fieldsToMap(v.Fields)
 		}
+
 		out[k] = fieldMap
 	}
+
 	return out
 }
 
@@ -140,24 +191,30 @@ func mapToFields(m map[string]interface{}) map[string]Field {
 	for k, v := range m {
 		if fieldMap, ok := v.(map[string]interface{}); ok {
 			f := Field{Name: k}
+
 			if typeName, ok := fieldMap["type"].(string); ok {
 				f.Type = typeName
 			}
+
 			if subFields, ok := fieldMap["fields"].(map[string]interface{}); ok {
 				f.Fields = mapToFields(subFields)
 			}
+
 			fields[k] = f
 		}
 	}
+
 	return fields
 }
 
 func loadSchemaForEntity(entity string) *Entity {
 	key := globals.ApiSingleEntityKey(SchemaEntity, entity)
 	data, _ := storage.GetJsonByKey(key)
+
 	schema := &Entity{ID: entity}
 	if fieldsMap, ok := data["fields"].(map[string]interface{}); ok {
 		schema.Fields = mapToFields(fieldsMap)
 	}
+
 	return schema
 }

--- a/internal/transport/http/api/get_schema.go
+++ b/internal/transport/http/api/get_schema.go
@@ -1,0 +1,30 @@
+package api
+
+import (
+	api_storage "github.com/taymour/elysiandb/internal/api"
+	"github.com/taymour/elysiandb/internal/schema"
+	"github.com/valyala/fasthttp"
+)
+
+func GetSchemaController(ctx *fasthttp.RequestCtx) {
+	entity := ctx.UserValue("entity").(string)
+
+	if !api_storage.EntityTypeExists(entity) {
+		ctx.SetStatusCode(fasthttp.StatusNotFound)
+		ctx.Response.Header.Set("Content-Type", "application/json")
+		ctx.SetBodyString(`{"error":"entity not found"}`)
+		return
+	}
+
+	raw, ok := api_storage.ReadEntityRawById(schema.SchemaEntity, entity)
+	if !ok || raw == nil {
+		ctx.SetStatusCode(fasthttp.StatusNotFound)
+		ctx.Response.Header.Set("Content-Type", "application/json")
+		ctx.SetBodyString(`{"error":"schema not found"}`)
+		return
+	}
+
+	ctx.Response.Header.Set("Content-Type", "application/json")
+	ctx.SetStatusCode(fasthttp.StatusOK)
+	ctx.SetBody(raw)
+}

--- a/test/internal/schema_test/analyzer_test.go
+++ b/test/internal/schema_test/analyzer_test.go
@@ -29,16 +29,14 @@ func TestAnalyzeEntitySchema_Simple(t *testing.T) {
 		t.Fatalf("expected id=users, got %v", result["id"])
 	}
 
-	fields, ok := result["fields"].(map[string]interface{})
-	if !ok {
-		t.Fatalf("expected fields map, got %T", result["fields"])
-	}
+	fields := result["fields"].(map[string]interface{})
 
 	if fields["name"].(map[string]interface{})["type"] != "string" {
 		t.Fatalf("expected type string for name, got %v", fields["name"].(map[string]interface{})["type"])
 	}
-	if fields["age"].(map[string]interface{})["type"] != "int" {
-		t.Fatalf("expected type int for age, got %v", fields["age"].(map[string]interface{})["type"])
+
+	if fields["age"].(map[string]interface{})["type"] != "number" {
+		t.Fatalf("expected type number for age, got %v", fields["age"].(map[string]interface{})["type"])
 	}
 }
 
@@ -60,8 +58,8 @@ func TestAnalyzeEntitySchema_Nested(t *testing.T) {
 	if subFields["name"].(map[string]interface{})["type"] != "string" {
 		t.Fatalf("expected nested field type string for author.name, got %v", subFields["name"].(map[string]interface{})["type"])
 	}
-	if subFields["age"].(map[string]interface{})["type"] != "int" {
-		t.Fatalf("expected nested field type int for author.age, got %v", subFields["age"].(map[string]interface{})["type"])
+	if subFields["age"].(map[string]interface{})["type"] != "number" {
+		t.Fatalf("expected nested field type number for author.age, got %v", subFields["age"].(map[string]interface{})["type"])
 	}
 }
 
@@ -70,7 +68,7 @@ func TestValidateEntity_ValidData(t *testing.T) {
 		ID: "users",
 		Fields: map[string]schema.Field{
 			"name": {Name: "name", Type: "string"},
-			"age":  {Name: "age", Type: "int"},
+			"age":  {Name: "age", Type: "number"},
 		},
 	}
 	restore := patchLoadSchema(mockSchema)
@@ -92,7 +90,7 @@ func TestValidateEntity_TypeMismatch(t *testing.T) {
 		ID: "users",
 		Fields: map[string]schema.Field{
 			"name": {Name: "name", Type: "string"},
-			"age":  {Name: "age", Type: "int"},
+			"age":  {Name: "age", Type: "number"},
 		},
 	}
 	restore := patchLoadSchema(mockSchema)
@@ -115,10 +113,10 @@ func TestValidateEntity_NestedMismatch(t *testing.T) {
 		Fields: map[string]schema.Field{
 			"customer": {
 				Name: "customer",
-				Type: "map[string]interface {}",
+				Type: "object",
 				Fields: map[string]schema.Field{
 					"name": {Name: "name", Type: "string"},
-					"age":  {Name: "age", Type: "int"},
+					"age":  {Name: "age", Type: "number"},
 				},
 			},
 		},


### PR DESCRIPTION
This PR adds schema introspection to ElysianDB through a new endpoint:

GET /api/<entity>/schema

Automatically returns the inferred schema for any entity.

Works with nested objects and arrays.

Returns proper errors when the entity or schema does not exist.

Fully integrated with the existing schema inference system.

This feature improves developer experience by making ElysianDB self-documenting and easier to explore, especially for front-end developers or tools that need dynamic type information.

Closes https://github.com/elysiandb/elysiandb/issues/95