### PR TITLE
Added put schema for rest api

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,41 +1,42 @@
-# ElysianDB — Lightweight KV Store with **Instant Zero-Config REST API**
+# ElysianDB — Lightweight KV Store with Instant Zero-Config REST API
 
 [![Docker Pulls](https://img.shields.io/docker/pulls/taymour/elysiandb.svg)](https://hub.docker.com/r/taymour/elysiandb)
 [![Tests](https://img.shields.io/github/actions/workflow/status/taymour/elysiandb/ci.yaml?branch=main\&label=tests)](https://github.com/taymour/elysiandb/actions/workflows/ci.yaml)
 [![Coverage](https://codecov.io/gh/elysiandb/elysiandb/branch/main/graph/badge.svg)](https://codecov.io/gh/taymour/elysiandb)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
-**ElysianDB** is a blazing-fast, in-memory key–value store with a **zero-configuration, auto-generated REST API**. Written in Go and optimized with a **sharded arena allocator**, **zero-copy GET path**, and **cache-friendly JSON storage**, ElysianDB lets you spin up a full backend in seconds.
+ElysianDB is a blazing-fast, in-memory key–value store with a zero-configuration, auto-generated REST API. Written in Go and optimized with a sharded arena allocator, zero-copy GET path, and cache-friendly JSON storage, ElysianDB lets you spin up a full backend in seconds.
 
-No schema files. No migrations. No ORMs. **Just start and query.**
+No schema files. No migrations. No ORMs. Just start and query.
 
 ---
 
 ## Highlights
 
-* **Instant REST API** — CRUD, pagination, sorting, filtering, includes (`/api/<entity>`) *with zero configuration*
-* **Fast In-Memory KV Engine** — sharded store, optional TTL, atomic counters
-* **Auto-Indexing** — lazy index creation on first sort request
-* **Schema-less JSON** — dynamic structures; IDs generated automatically
-* **Optional Schema Validation** — infer schema from first POST, enforce afterwards
-* **Nested Entity Creation** — auto-create sub-entities via `@entity` fields
-* **Persistence** — periodic flush + crash recovery log
-* **Protocols** — HTTP REST, TCP (Redis-style text protocol)
-* **Built for Speed** — no GC churn thanks to arena allocation
+* Instant REST API — CRUD, pagination, filtering, sorting, includes (/api/<entity>) with zero configuration
+* Fast In-Memory KV Engine — sharded store, optional TTL, atomic counters
+* Auto-Indexing — lazy index creation on first sort request
+* Schema-less JSON — dynamic structures; IDs generated automatically
+* Automatic Schema Inference — schemas inferred from observed documents
+* Schema API — GET /api/<entity>/schema for live schema inspection
+* Manual Schema Override — PUT /api/<entity>/schema to define strict schemas
+* Strict Schema Validation — reject writes that do not match the manual schema
+* Nested Entity Creation — auto-create sub-entities via @entity fields
+* Persistence — periodic flush plus crash recovery log
+* Protocols — HTTP REST, TCP (Redis-style text protocol)
+* High performance — minimal allocations and cache-friendly design
 
 ---
 
 ## Quick Example
 
 ```js
-// Create an entity
 await fetch("http://localhost:8089/api/articles", {
   method: "POST",
   headers: { "Content-Type": "application/json" },
-  body: JSON.stringify({ title: "Hello", tags: ["go", "kv"], published: true }),
+  body: JSON.stringify({ title: "Hello", tags: ["go", "kv"], published: true })
 });
 
-// Fetch with pagination & sorting
 const res = await fetch("http://localhost:8089/api/articles?limit=20&offset=0&sort[title]=asc");
 const articles = await res.json();
 ```
@@ -44,25 +45,53 @@ const articles = await res.json();
 
 ## Performance Benchmarks (MacBook Pro M4)
 
-Run with **mixed CRUD, filtering, sorting, nested create, includes**, and heavy JSON workloads — not microbenchmarks.
+Mixed CRUD, filtering, sorting, nested create, includes. Not microbenchmarks.
 
 ### Summary
 
-| Scenario       | Load                | p95 Latency | RPS      | Errors |
-| -------------- | ------------------- | ----------- | -------- | ------ |
-| **Dev Local**  | 3 VUs / 100 keys    | **62 µs**   | ~52.7k/s | 0%     |
-| **Small App**  | 10 VUs / 500 keys   | **184 µs**  | ~81.3k/s | 0%     |
-| **Light Prod** | 25 VUs / 1000 keys  | **412 µs**  | ~95.5k/s | 0%     |
-| **Heavy Load** | 200 VUs / 5000 keys | **12.6 ms** | ~60.6k/s | 0%     |
+| Scenario   | Load                | p95 Latency | RPS      | Errors |
+| ---------- | ------------------- | ----------- | -------- | ------ |
+| Dev Local  | 3 VUs / 100 keys    | 62 µs       | ~52.7k/s | 0%     |
+| Small App  | 10 VUs / 500 keys   | 184 µs      | ~81.3k/s | 0%     |
+| Light Prod | 25 VUs / 1000 keys  | 412 µs      | ~95.5k/s | 0%     |
+| Heavy Load | 200 VUs / 5000 keys | 12.6 ms     | ~60.6k/s | 0%     |
 
-### Why this matters
+---
 
-* **Sub-millisecond latency** up to 25 VUs
-* **~60k requests/second** under heavy mixed load
-* **Zero errors** across millions of requests
-* **1.7 GB/s response throughput**, on a laptop
+## Schema Features
 
-> **Bottom line:** ElysianDB outperforms most REST backends on mixed JSON workloads — while staying simpler than MongoDB.
+ElysianDB now includes complete schema handling:
+
+### Automatic Inference
+
+* First inserted document defines the inferred schema
+* Schema evolves as fields appear, unless strict mode is enabled
+
+### Schema Inspection
+
+* GET /api/<entity>/schema returns the current schema
+
+### Manual Schema Definition
+
+* PUT /api/<entity>/schema replaces the inferred schema and locks it
+* Manual schemas take precedence and stop automatic evolution
+
+### Strict Mode
+
+Configured via:
+
+```yaml
+api:
+  schema:
+    enabled: true
+    strict: true
+```
+
+When strict is enabled:
+
+* New fields are rejected
+* Writes must match the schema exactly
+* Nested fields and arrays are validated recursively
 
 ---
 
@@ -81,7 +110,7 @@ store:
   flushIntervalSeconds: 5
   crashRecovery: { enabled: true, maxLogMB: 100 }
   json:
-    arenaChunkSize: 1048576  # 1 MiB
+    arenaChunkSize: 1048576
 server:
   http: { enabled: true, host: 0.0.0.0, port: 8089 }
   tcp:  { enabled: true, host: 0.0.0.0, port: 8088 }
@@ -94,6 +123,7 @@ api:
     workers: 4
   schema:
     enabled: true
+    strict: false
   cache:
     enabled: true
     cleanupIntervalSeconds: 10
@@ -103,33 +133,34 @@ api:
 
 ## Protocols
 
-### **HTTP REST**
+### HTTP REST
 
-* `POST   /api/<entity>` → Create
-* `GET    /api/<entity>` → List (pagination, filtering, sorting)
-* `GET    /api/<entity>/<id>` → Read
-* `PUT    /api/<entity>/<id>` → Update
-* `DELETE /api/<entity>/<id>` → Delete
-* `GET    /api/<entity>/schema` → Schema for entity (if config api.schema is enabled)
+* POST /api/<entity> → Create
+* GET /api/<entity> → List (pagination, filtering, sorting)
+* GET /api/<entity>/<id> → Read
+* PUT /api/<entity>/<id> → Update
+* DELETE /api/<entity>/<id> → Delete
+* GET /api/<entity>/schema → Retrieve schema
+* PUT /api/<entity>/schema → Define manual schema and enable strict mode
 
-### **TCP (Redis-style)**
+### TCP (Redis-style)
 
-* `SET <key> <value>`
-* `GET <key>` / `MGET key1 key2`
-* `DEL <key>` / `RESET` / `SAVE` / `PING`
+* SET <key> <value>
+* GET <key> / MGET key1 key2
+* DEL <key> / RESET / SAVE / PING
 
 ---
 
-## Persistence & Stats
+## Persistence and Stats
 
 * Periodic flush to disk
 * Crash-safe write-ahead log
 * Graceful shutdown flush
-* `/stats` endpoint for runtime metrics
+* /stats endpoint for runtime metrics
 
 ---
 
-## Build & Run
+## Build and Run
 
 ```bash
 go build && ./elysiandb
@@ -139,4 +170,4 @@ go run elysiandb.go
 
 ---
 
-ElysianDB is built to be **simple**, **fast**, and **practical** — a real backend you can ship in minutes.
+ElysianDB is built to be simple, fast, and practical — a real backend you can ship in minutes.

--- a/elysian.yaml
+++ b/elysian.yaml
@@ -15,6 +15,7 @@ stats:
 api:
   schema:
     enabled: true
+    strict: true
   index:
     workers: 4
   cache:

--- a/internal/api/storage.go
+++ b/internal/api/storage.go
@@ -11,6 +11,10 @@ import (
 )
 
 func WriteEntity(entity string, data map[string]interface{}) []schema.ValidationError {
+	if entity == schema.SchemaEntity {
+		data["_manual"] = true
+	}
+
 	if globals.GetConfig().Api.Schema.Enabled && entity != schema.SchemaEntity {
 		errors := schema.ValidateEntity(entity, data)
 		if len(errors) > 0 {
@@ -30,7 +34,10 @@ func WriteEntity(entity string, data map[string]interface{}) []schema.Validation
 	}
 
 	persistEntity(entity, data)
-	updateSchemaIfNeeded(entity, data)
+
+	if !(schema.IsManualSchema(entity) && globals.GetConfig().Api.Schema.Strict) {
+		updateSchemaIfNeeded(entity, data)
+	}
 
 	return []schema.ValidationError{}
 }

--- a/internal/configuration/loader.go
+++ b/internal/configuration/loader.go
@@ -54,6 +54,7 @@ type StatsConfig struct {
 
 type ApiSchemaConfig struct {
 	Enabled bool `yaml:"enabled"`
+	Strict  bool `yaml:"strict"`
 }
 
 type ApiConfig struct {

--- a/internal/routing/router.go
+++ b/internal/routing/router.go
@@ -37,6 +37,7 @@ func RegisterRoutes(r *router.Router) {
 
 	if globals.GetConfig().Api.Schema.Enabled {
 		r.GET("/api/{entity}/schema", Version(api.GetSchemaController))
+		r.PUT("/api/{entity}/schema", Version(api.PutSchemaController))
 	}
 }
 

--- a/internal/transport/http/api/create.go
+++ b/internal/transport/http/api/create.go
@@ -7,6 +7,7 @@ import (
 	api_storage "github.com/taymour/elysiandb/internal/api"
 	"github.com/taymour/elysiandb/internal/cache"
 	"github.com/taymour/elysiandb/internal/globals"
+	"github.com/taymour/elysiandb/internal/schema"
 	"github.com/valyala/fasthttp"
 )
 
@@ -14,13 +15,44 @@ func CreateController(ctx *fasthttp.RequestCtx) {
 	entity := ctx.UserValue("entity").(string)
 	body := ctx.PostBody()
 
+	if globals.GetConfig().Api.Schema.Strict && schema.IsManualSchema(entity) {
+		var tmp interface{}
+		if json.Unmarshal(body, &tmp) == nil {
+			if obj, ok := tmp.(map[string]interface{}); ok {
+				if errs := schema.ValidateEntity(entity, obj); len(errs) > 0 {
+					b, _ := json.Marshal(errs)
+					ctx.SetStatusCode(fasthttp.StatusBadRequest)
+					ctx.Response.Header.Set("Content-Type", "application/json")
+					ctx.SetBody(b)
+
+					return
+				}
+			}
+
+			if arr, ok := tmp.([]interface{}); ok {
+				for _, it := range arr {
+					if obj, ok := it.(map[string]interface{}); ok {
+						if errs := schema.ValidateEntity(entity, obj); len(errs) > 0 {
+							b, _ := json.Marshal(errs)
+							ctx.SetStatusCode(fasthttp.StatusBadRequest)
+							ctx.Response.Header.Set("Content-Type", "application/json")
+							ctx.SetBody(b)
+
+							return
+						}
+					}
+				}
+			}
+		}
+	}
+
 	if handleSingleEntity(ctx, entity, body) {
-		finalizeCreate(ctx, entity)
+		finalizeCreate(entity)
 		return
 	}
 
 	if handleEntityList(ctx, entity, body) {
-		finalizeCreate(ctx, entity)
+		finalizeCreate(entity)
 		return
 	}
 
@@ -33,10 +65,12 @@ func handleSingleEntity(ctx *fasthttp.RequestCtx, entity string, body []byte) bo
 	if err := json.Unmarshal(body, &data); err != nil || len(data) == 0 {
 		return false
 	}
+
 	id, hasId := data["id"].(string)
 	if !hasId || id == "" {
 		data["id"] = uuid.New().String()
 	}
+
 	errors := api_storage.WriteEntity(entity, data)
 	if len(errors) > 0 {
 		response, _ := json.Marshal(errors)
@@ -59,6 +93,7 @@ func handleEntityList(ctx *fasthttp.RequestCtx, entity string, body []byte) bool
 	if err := json.Unmarshal(body, &list); err != nil || len(list) == 0 {
 		return false
 	}
+
 	for i := range list {
 		id, hasId := list[i]["id"].(string)
 		if !hasId || id == "" {
@@ -88,10 +123,11 @@ func handleEntityList(ctx *fasthttp.RequestCtx, entity string, body []byte) bool
 	ctx.Response.Header.Set("Content-Type", "application/json")
 	ctx.SetStatusCode(fasthttp.StatusOK)
 	ctx.SetBody(response)
+
 	return true
 }
 
-func finalizeCreate(ctx *fasthttp.RequestCtx, entity string) {
+func finalizeCreate(entity string) {
 	if globals.GetConfig().Api.Cache.Enabled {
 		cache.CacheStore.Purge(entity)
 	}

--- a/internal/transport/http/api/put_schema.go
+++ b/internal/transport/http/api/put_schema.go
@@ -1,0 +1,44 @@
+package api
+
+import (
+	"encoding/json"
+
+	api_storage "github.com/taymour/elysiandb/internal/api"
+	"github.com/valyala/fasthttp"
+)
+
+func PutSchemaController(ctx *fasthttp.RequestCtx) {
+	entity := ctx.UserValue("entity").(string)
+
+	if !api_storage.EntityTypeExists(entity) {
+		ctx.SetStatusCode(fasthttp.StatusNotFound)
+		ctx.SetBodyString(`{"error":"entity not found"}`)
+		return
+	}
+
+	var payload map[string]interface{}
+	if err := json.Unmarshal(ctx.PostBody(), &payload); err != nil {
+		ctx.SetStatusCode(fasthttp.StatusBadRequest)
+		ctx.SetBodyString(`{"error":"invalid json"}`)
+		return
+	}
+
+	fields, ok := payload["fields"].(map[string]interface{})
+	if !ok {
+		ctx.SetStatusCode(fasthttp.StatusBadRequest)
+		ctx.SetBodyString(`{"error":"schema.fields must be an object"}`)
+		return
+	}
+
+	schemaData := map[string]interface{}{
+		"id":      entity,
+		"fields":  fields,
+		"_manual": true,
+	}
+
+	api_storage.WriteEntity("schema", schemaData)
+
+	out, _ := json.Marshal(schemaData)
+	ctx.SetStatusCode(fasthttp.StatusOK)
+	ctx.SetBody(out)
+}

--- a/test/e2e/api/schema.go
+++ b/test/e2e/api/schema.go
@@ -1,0 +1,210 @@
+package e2e
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/taymour/elysiandb/internal/globals"
+	"github.com/valyala/fasthttp"
+)
+
+func TestSchemaStrict_PutSchema_Create_Update_Validation(t *testing.T) {
+	client, stop := startTestServer(t)
+	defer stop()
+
+	cfg := globals.GetConfig()
+	cfg.Api.Schema.Enabled = true
+	cfg.Api.Schema.Strict = true
+	globals.SetConfig(cfg)
+
+	put1 := mustPUTJSON(t, client, "http://test/api/books/schema", map[string]any{
+		"fields": map[string]any{
+			"title": map[string]any{"type": "string"},
+			"pages": map[string]any{"type": "number"},
+		},
+	})
+	if put1.StatusCode() != fasthttp.StatusOK {
+		t.Fatalf("expected 200 for PUT schema, got %d", put1.StatusCode())
+	}
+
+	gr := mustGET(t, client, "http://test/api/books/schema")
+	if gr.StatusCode() != fasthttp.StatusOK {
+		t.Fatalf("expected 200 for schema get, got %d", gr.StatusCode())
+	}
+	var schema map[string]any
+	_ = json.Unmarshal(gr.Body(), &schema)
+	fields := schema["fields"].(map[string]any)
+	if fields["title"].(map[string]any)["type"] != "string" {
+		t.Fatalf("title type mismatch")
+	}
+
+	c1 := mustPOSTJSON(t, client, "http://test/api/books", map[string]any{
+		"title": "Go",
+		"pages": 123,
+	})
+	if c1.StatusCode() != fasthttp.StatusOK {
+		t.Fatalf("expected 200 on valid create, got %d", c1.StatusCode())
+	}
+
+	c2 := mustPOSTJSON(t, client, "http://test/api/books", map[string]any{
+		"title": 999,
+		"pages": 123,
+	})
+	if c2.StatusCode() == fasthttp.StatusOK {
+		t.Fatalf("expected validation error for wrong title type")
+	}
+
+	var created map[string]any
+	_ = json.Unmarshal(c1.Body(), &created)
+	id := created["id"].(string)
+
+	up1 := mustPUTJSON(t, client, "http://test/api/books/"+id, map[string]any{
+		"title": "Updated Title",
+		"pages": 200,
+	})
+	if up1.StatusCode() != fasthttp.StatusOK {
+		t.Fatalf("expected 200 on valid update, got %d", up1.StatusCode())
+	}
+
+	up2 := mustPUTJSON(t, client, "http://test/api/books/"+id, map[string]any{
+		"title": "Bad",
+		"pages": "wrong",
+	})
+	if up2.StatusCode() == fasthttp.StatusOK {
+		t.Fatalf("expected validation error on update wrong type")
+	}
+
+	mustPOSTJSON(t, client, "http://test/api/books", map[string]any{
+		"title": "New",
+		"pages": 10,
+	})
+
+	gr2 := mustGET(t, client, "http://test/api/books/schema")
+	var schema2 map[string]any
+	_ = json.Unmarshal(gr2.Body(), &schema2)
+	fields2 := schema2["fields"].(map[string]any)
+	if len(fields2) != 2 {
+		t.Fatalf("schema should not auto-update in strict mode")
+	}
+}
+
+func TestSchemaStrict_PutSchema_AddNewFieldRejected(t *testing.T) {
+	client, stop := startTestServer(t)
+	defer stop()
+
+	cfg := globals.GetConfig()
+	cfg.Api.Schema.Enabled = true
+	cfg.Api.Schema.Strict = true
+	globals.SetConfig(cfg)
+
+	mustPUTJSON(t, client, "http://test/api/users/schema", map[string]any{
+		"fields": map[string]any{
+			"name": map[string]any{"type": "string"},
+		},
+	})
+
+	r1 := mustPOSTJSON(t, client, "http://test/api/users", map[string]any{
+		"name": "Alice",
+	})
+	if r1.StatusCode() != fasthttp.StatusOK {
+		t.Fatalf("expected 200, got %d", r1.StatusCode())
+	}
+
+	r2 := mustPOSTJSON(t, client, "http://test/api/users", map[string]any{
+		"name": "Bob",
+		"age":  22,
+	})
+	if r2.StatusCode() == fasthttp.StatusOK {
+		t.Fatalf("unexpected success: strict schema should reject new field")
+	}
+}
+
+func TestSchemaStrict_UpdateSchema_ThenValidateNewRules(t *testing.T) {
+	client, stop := startTestServer(t)
+	defer stop()
+
+	cfg := globals.GetConfig()
+	cfg.Api.Schema.Enabled = true
+	cfg.Api.Schema.Strict = true
+	globals.SetConfig(cfg)
+
+	mustPUTJSON(t, client, "http://test/api/profiles/schema", map[string]any{
+		"fields": map[string]any{
+			"username": map[string]any{"type": "string"},
+		},
+	})
+
+	r1 := mustPOSTJSON(t, client, "http://test/api/profiles", map[string]any{
+		"username": "x",
+	})
+	if r1.StatusCode() != 200 {
+		t.Fatalf("expected 200")
+	}
+
+	put2 := mustPUTJSON(t, client, "http://test/api/profiles/schema", map[string]any{
+		"fields": map[string]any{
+			"username": map[string]any{"type": "string"},
+			"score":    map[string]any{"type": "number"},
+		},
+	})
+	if put2.StatusCode() != 200 {
+		t.Fatalf("expected 200 on schema update")
+	}
+
+	r2 := mustPOSTJSON(t, client, "http://test/api/profiles", map[string]any{
+		"username": "y",
+	})
+	if r2.StatusCode() != fasthttp.StatusOK {
+		t.Fatalf("expected 200 without score")
+	}
+
+	r3 := mustPOSTJSON(t, client, "http://test/api/profiles", map[string]any{
+		"username": "z",
+		"score":    10,
+	})
+	if r3.StatusCode() != 200 {
+		t.Fatalf("expected 200 with valid score")
+	}
+
+	r4 := mustPOSTJSON(t, client, "http://test/api/profiles", map[string]any{
+		"username": "bad",
+		"score":    "wrong",
+	})
+	if r4.StatusCode() == 200 {
+		t.Fatalf("expected failure on wrong score type")
+	}
+}
+
+func TestSchemaStrict_GetAfterPut(t *testing.T) {
+	client, stop := startTestServer(t)
+	defer stop()
+
+	cfg := globals.GetConfig()
+	cfg.Api.Schema.Enabled = true
+	cfg.Api.Schema.Strict = true
+	globals.SetConfig(cfg)
+
+	put := mustPUTJSON(t, client, "http://test/api/accounts/schema", map[string]any{
+		"fields": map[string]any{
+			"email": map[string]any{"type": "string"},
+			"age":   map[string]any{"type": "number"},
+		},
+	})
+	if put.StatusCode() != 200 {
+		t.Fatalf("expected 200")
+	}
+
+	gr := mustGET(t, client, "http://test/api/accounts/schema")
+	if gr.StatusCode() != 200 {
+		t.Fatalf("expected 200")
+	}
+	var s map[string]any
+	_ = json.Unmarshal(gr.Body(), &s)
+	f := s["fields"].(map[string]any)
+	if f["email"].(map[string]any)["type"] != "string" {
+		t.Fatalf("missing email")
+	}
+	if f["age"].(map[string]any)["type"] != "number" {
+		t.Fatalf("missing age")
+	}
+}


### PR DESCRIPTION
This PR introduces manual schema management for the REST API.
It adds a new endpoint, `PUT /api/<entity>/schema`, allowing users to define schemas explicitly.
Once a manual schema is set, the entity switches to strict mode: writes must match the schema exactly, and automatic schema evolution is disabled.

Key additions:

* Manual schema definition (`PUT /api/<entity>/schema`)
* `_manual` flag persisted in schema entries
* Strict validation for POST/PUT when manual schema exists
* Config support for `api.schema.strict`
* Updated automatic schema inference logic

Closes https://github.com/elysiandb/elysiandb/issues/96