### PR TITLE
Added basic transaction system for /api

### DIFF
--- a/internal/routing/router.go
+++ b/internal/routing/router.go
@@ -4,6 +4,7 @@ import (
 	"github.com/fasthttp/router"
 	"github.com/taymour/elysiandb/internal/globals"
 	"github.com/taymour/elysiandb/internal/transport/http/api"
+	api_transaction "github.com/taymour/elysiandb/internal/transport/http/api/transactions"
 	"github.com/taymour/elysiandb/internal/transport/http/controller"
 	"github.com/valyala/fasthttp"
 )
@@ -41,6 +42,13 @@ func RegisterRoutes(r *router.Router) {
 		r.GET("/api/{entity}/schema", Version(api.GetSchemaController))
 		r.PUT("/api/{entity}/schema", Version(api.PutSchemaController))
 	}
+
+	r.POST("/api/tx/begin", Version(api_transaction.BeginTransactionController))
+	r.POST("/api/tx/{txId}/rollback", Version(api_transaction.RollbackTransactionController))
+	r.POST("/api/tx/{txId}/entity/{entity}", Version(api_transaction.WriteTransactionController))
+	r.PUT("/api/tx/{txId}/entity/{entity}/{id}", Version(api_transaction.UpdateTransactionController))
+	r.DELETE("/api/tx/{txId}/entity/{entity}/{id}", Version(api_transaction.DeleteTransactionController))
+	r.POST("/api/tx/{txId}/commit", Version(api_transaction.CommitTransactionController))
 }
 
 func Version(requestHandler fasthttp.RequestHandler) fasthttp.RequestHandler {

--- a/internal/transaction/transaction.go
+++ b/internal/transaction/transaction.go
@@ -1,0 +1,148 @@
+package transaction
+
+import (
+	"errors"
+	"sync"
+	"time"
+
+	api_storage "github.com/taymour/elysiandb/internal/api"
+	"github.com/taymour/elysiandb/internal/schema"
+)
+
+type TxOperation struct {
+	Kind   string
+	Entity string
+	ID     string
+	Data   map[string]interface{}
+}
+
+type Transaction struct {
+	ID        string
+	Ops       []TxOperation
+	StartedAt time.Time
+}
+
+func StorageImpl() Storage {
+	return storageImpl
+}
+
+func SetStorageImpl(s Storage) {
+	storageImpl = s
+}
+
+type Storage interface {
+	WriteEntity(entity string, data map[string]interface{}) []schema.ValidationError
+	UpdateEntityById(entity, id string, data map[string]interface{}) map[string]interface{}
+	DeleteEntityById(entity, id string)
+}
+
+type realStorage struct{}
+
+func (realStorage) WriteEntity(e string, d map[string]interface{}) []schema.ValidationError {
+	return api_storage.WriteEntity(e, d)
+}
+
+func (realStorage) UpdateEntityById(e, id string, d map[string]interface{}) map[string]interface{} {
+	return api_storage.UpdateEntityById(e, id, d)
+}
+
+func (realStorage) DeleteEntityById(e, id string) {
+	api_storage.DeleteEntityById(e, id)
+}
+
+var storageImpl Storage = realStorage{}
+
+var TxManager = struct {
+	mu  sync.Mutex
+	txs map[string]*Transaction
+}{txs: map[string]*Transaction{}}
+
+func BeginTransaction() *Transaction {
+	TxManager.mu.Lock()
+	defer TxManager.mu.Unlock()
+
+	txID := generateTxID()
+	tx := &Transaction{
+		ID:        txID,
+		Ops:       []TxOperation{},
+		StartedAt: time.Now(),
+	}
+	TxManager.txs[txID] = tx
+
+	return tx
+}
+
+func generateTxID() string {
+	return time.Now().Format("20060102150405.000000000")
+}
+
+func GetTransaction(txID string) (*Transaction, error) {
+	TxManager.mu.Lock()
+	defer TxManager.mu.Unlock()
+
+	tx, ok := TxManager.txs[txID]
+	if !ok {
+		return nil, errors.New("transaction not found")
+	}
+
+	return tx, nil
+}
+
+func AddOperation(txID string, op TxOperation) error {
+	TxManager.mu.Lock()
+	defer TxManager.mu.Unlock()
+
+	tx, ok := TxManager.txs[txID]
+	if !ok {
+		return errors.New("transaction not found")
+	}
+
+	tx.Ops = append(tx.Ops, op)
+
+	return nil
+}
+
+func CommitTransaction(txID string) error {
+	TxManager.mu.Lock()
+	tx, ok := TxManager.txs[txID]
+	if !ok {
+		TxManager.mu.Unlock()
+
+		return errors.New("transaction not found")
+	}
+
+	delete(TxManager.txs, txID)
+	TxManager.mu.Unlock()
+
+	for _, op := range tx.Ops {
+		switch op.Kind {
+		case "write":
+			errs := storageImpl.WriteEntity(op.Entity, op.Data)
+			if len(errs) > 0 {
+				return errors.New("validation error")
+			}
+		case "update":
+			res := storageImpl.UpdateEntityById(op.Entity, op.ID, op.Data)
+			if res == nil {
+				return errors.New("update failed")
+			}
+		case "delete":
+			storageImpl.DeleteEntityById(op.Entity, op.ID)
+		}
+	}
+
+	return nil
+}
+
+func RollbackTransaction(txID string) error {
+	TxManager.mu.Lock()
+	defer TxManager.mu.Unlock()
+
+	if _, exists := TxManager.txs[txID]; !exists {
+		return nil
+	}
+
+	delete(TxManager.txs, txID)
+
+	return nil
+}

--- a/internal/transport/http/api/transactions/begin.go
+++ b/internal/transport/http/api/transactions/begin.go
@@ -1,0 +1,13 @@
+package api_transaction
+
+import (
+	"github.com/taymour/elysiandb/internal/transaction"
+	"github.com/valyala/fasthttp"
+)
+
+func BeginTransactionController(ctx *fasthttp.RequestCtx) {
+	ctx.Response.Header.Set("Content-Type", "application/json")
+	tx := transaction.BeginTransaction()
+	ctx.Response.SetBodyString(`{"transaction_id":"` + tx.ID + `"}`)
+	ctx.SetStatusCode(fasthttp.StatusOK)
+}

--- a/internal/transport/http/api/transactions/commit.go
+++ b/internal/transport/http/api/transactions/commit.go
@@ -1,0 +1,22 @@
+package api_transaction
+
+import (
+	"github.com/taymour/elysiandb/internal/transaction"
+	"github.com/valyala/fasthttp"
+)
+
+func CommitTransactionController(ctx *fasthttp.RequestCtx) {
+	ctx.Response.Header.Set("Content-Type", "application/json")
+
+	txID := ctx.UserValue("txId").(string)
+
+	err := transaction.CommitTransaction(txID)
+	if err != nil {
+		ctx.SetStatusCode(fasthttp.StatusBadRequest)
+		ctx.SetBodyString(`{"error":"` + err.Error() + `"}`)
+
+		return
+	}
+
+	ctx.SetStatusCode(fasthttp.StatusOK)
+}

--- a/internal/transport/http/api/transactions/delete.go
+++ b/internal/transport/http/api/transactions/delete.go
@@ -1,0 +1,31 @@
+package api_transaction
+
+import (
+	"github.com/taymour/elysiandb/internal/transaction"
+	"github.com/valyala/fasthttp"
+)
+
+func DeleteTransactionController(ctx *fasthttp.RequestCtx) {
+	ctx.Response.Header.Set("Content-Type", "application/json")
+
+	txID := ctx.UserValue("txId").(string)
+	entity := ctx.UserValue("entity").(string)
+	id := ctx.UserValue("id").(string)
+
+	op := transaction.TxOperation{
+		Kind:   "delete",
+		Entity: entity,
+		ID:     id,
+		Data:   nil,
+	}
+
+	err := transaction.AddOperation(txID, op)
+	if err != nil {
+		ctx.SetStatusCode(fasthttp.StatusBadRequest)
+		ctx.SetBodyString(`{"error":"` + err.Error() + `"}`)
+
+		return
+	}
+
+	ctx.SetStatusCode(fasthttp.StatusOK)
+}

--- a/internal/transport/http/api/transactions/rollback.go
+++ b/internal/transport/http/api/transactions/rollback.go
@@ -1,0 +1,21 @@
+package api_transaction
+
+import (
+	"github.com/taymour/elysiandb/internal/transaction"
+	"github.com/valyala/fasthttp"
+)
+
+func RollbackTransactionController(ctx *fasthttp.RequestCtx) {
+	ctx.Response.Header.Set("Content-Type", "application/json")
+	txID := ctx.UserValue("txId").(string)
+
+	err := transaction.RollbackTransaction(txID)
+	if err != nil {
+		ctx.SetStatusCode(fasthttp.StatusInternalServerError)
+		ctx.SetBody([]byte(`{"error":"` + err.Error() + `"}`))
+
+		return
+	}
+
+	ctx.SetStatusCode(fasthttp.StatusOK)
+}

--- a/internal/transport/http/api/transactions/update.go
+++ b/internal/transport/http/api/transactions/update.go
@@ -1,0 +1,72 @@
+package api_transaction
+
+import (
+	"encoding/json"
+
+	api_storage "github.com/taymour/elysiandb/internal/api"
+	"github.com/taymour/elysiandb/internal/globals"
+	"github.com/taymour/elysiandb/internal/schema"
+	"github.com/taymour/elysiandb/internal/transaction"
+	"github.com/valyala/fasthttp"
+)
+
+func UpdateTransactionController(ctx *fasthttp.RequestCtx) {
+	ctx.Response.Header.Set("Content-Type", "application/json")
+
+	txID := ctx.UserValue("txId").(string)
+	entity := ctx.UserValue("entity").(string)
+	id := ctx.UserValue("id").(string)
+
+	var payload map[string]interface{}
+	err := json.Unmarshal(ctx.PostBody(), &payload)
+	if err != nil {
+		ctx.SetStatusCode(fasthttp.StatusBadRequest)
+		ctx.SetBodyString(`{"error":"invalid json"}`)
+
+		return
+	}
+
+	existing := api_storage.ReadEntityById(entity, id)
+	if existing == nil {
+		ctx.SetStatusCode(fasthttp.StatusBadRequest)
+		ctx.SetBodyString(`{"error":"entity not found"}`)
+
+		return
+	}
+
+	merged := make(map[string]interface{}, len(existing))
+	for k, v := range existing {
+		merged[k] = v
+	}
+
+	for k, v := range payload {
+		merged[k] = v
+	}
+
+	if globals.GetConfig().Api.Schema.Enabled && entity != schema.SchemaEntity {
+		errors := schema.ValidateEntity(entity, merged)
+		if len(errors) > 0 {
+			ctx.SetStatusCode(fasthttp.StatusBadRequest)
+			ctx.SetBodyString(`{"error":"schema validation failed"}`)
+
+			return
+		}
+	}
+
+	op := transaction.TxOperation{
+		Kind:   "update",
+		Entity: entity,
+		ID:     id,
+		Data:   payload,
+	}
+
+	err = transaction.AddOperation(txID, op)
+	if err != nil {
+		ctx.SetStatusCode(fasthttp.StatusBadRequest)
+		ctx.SetBodyString(`{"error":"` + err.Error() + `"}`)
+
+		return
+	}
+
+	ctx.SetStatusCode(fasthttp.StatusOK)
+}

--- a/internal/transport/http/api/transactions/write.go
+++ b/internal/transport/http/api/transactions/write.go
@@ -1,0 +1,52 @@
+package api_transaction
+
+import (
+	"encoding/json"
+
+	"github.com/taymour/elysiandb/internal/globals"
+	"github.com/taymour/elysiandb/internal/schema"
+	"github.com/taymour/elysiandb/internal/transaction"
+	"github.com/valyala/fasthttp"
+)
+
+func WriteTransactionController(ctx *fasthttp.RequestCtx) {
+	ctx.Response.Header.Set("Content-Type", "application/json")
+
+	txID := ctx.UserValue("txId").(string)
+	entity := ctx.UserValue("entity").(string)
+
+	var payload map[string]interface{}
+	err := json.Unmarshal(ctx.PostBody(), &payload)
+	if err != nil {
+		ctx.SetStatusCode(fasthttp.StatusBadRequest)
+		ctx.SetBodyString(`{"error":"invalid json"}`)
+
+		return
+	}
+
+	if globals.GetConfig().Api.Schema.Enabled && entity != schema.SchemaEntity {
+		errors := schema.ValidateEntity(entity, payload)
+		if len(errors) > 0 {
+			ctx.SetStatusCode(fasthttp.StatusBadRequest)
+			ctx.SetBodyString(`{"error":"schema validation failed"}`)
+
+			return
+		}
+	}
+
+	op := transaction.TxOperation{
+		Kind:   "write",
+		Entity: entity,
+		Data:   payload,
+	}
+
+	err = transaction.AddOperation(txID, op)
+	if err != nil {
+		ctx.SetStatusCode(fasthttp.StatusBadRequest)
+		ctx.SetBodyString(`{"error":"` + err.Error() + `"}`)
+
+		return
+	}
+
+	ctx.SetStatusCode(fasthttp.StatusOK)
+}

--- a/test/e2e/api/transaction.go
+++ b/test/e2e/api/transaction.go
@@ -1,0 +1,285 @@
+package e2e
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/taymour/elysiandb/internal/globals"
+	"github.com/valyala/fasthttp"
+)
+
+func TestTransactions_Create_Update_Delete_Commit(t *testing.T) {
+	client, stop := startTestServer(t)
+	defer stop()
+
+	beginResp := mustPOSTJSON(t, client, "http://test/api/tx/begin", nil)
+	var beginOut map[string]any
+	_ = json.Unmarshal(beginResp.Body(), &beginOut)
+	txID := beginOut["transaction_id"].(string)
+
+	w1 := mustPOSTJSON(t, client, "http://test/api/tx/"+txID+"/entity/books", map[string]any{
+		"title": "T1",
+		"pages": 100,
+	})
+	if w1.StatusCode() != fasthttp.StatusOK {
+		t.Fatalf("unexpected write1 status %d", w1.StatusCode())
+	}
+
+	w2 := mustPOSTJSON(t, client, "http://test/api/tx/"+txID+"/entity/books", map[string]any{
+		"title": "T2",
+		"pages": 200,
+	})
+	if w2.StatusCode() != fasthttp.StatusOK {
+		t.Fatalf("unexpected write2 status %d", w2.StatusCode())
+	}
+
+	listBefore := mustGET(t, client, "http://test/api/books")
+	var before []map[string]any
+	_ = json.Unmarshal(listBefore.Body(), &before)
+	if len(before) != 0 {
+		t.Fatalf("expected empty before commit, got %v", before)
+	}
+
+	commit := mustPOSTJSON(t, client, "http://test/api/tx/"+txID+"/commit", nil)
+	if commit.StatusCode() != fasthttp.StatusOK {
+		t.Fatalf("unexpected commit status %d", commit.StatusCode())
+	}
+
+	listAfter := mustGET(t, client, "http://test/api/books")
+	var after []map[string]any
+	_ = json.Unmarshal(listAfter.Body(), &after)
+	if len(after) != 2 {
+		t.Fatalf("expected 2 after commit, got %v", after)
+	}
+}
+
+func TestTransactions_UpdateInsideTransaction(t *testing.T) {
+	client, stop := startTestServer(t)
+	defer stop()
+
+	create := mustPOSTJSON(t, client, "http://test/api/articles", map[string]any{
+		"title": "Old",
+	})
+	var created map[string]any
+	_ = json.Unmarshal(create.Body(), &created)
+	id := created["id"].(string)
+
+	begin := mustPOSTJSON(t, client, "http://test/api/tx/begin", nil)
+	var out map[string]any
+	_ = json.Unmarshal(begin.Body(), &out)
+	txID := out["transaction_id"].(string)
+
+	up := mustPUTJSON(t, client, "http://test/api/tx/"+txID+"/entity/articles/"+id, map[string]any{
+		"title": "New",
+	})
+	if up.StatusCode() != fasthttp.StatusOK {
+		t.Fatalf("update failed: %d", up.StatusCode())
+	}
+
+	grBefore := mustGET(t, client, "http://test/api/articles/"+id)
+	var old map[string]any
+	_ = json.Unmarshal(grBefore.Body(), &old)
+	if old["title"] != "Old" {
+		t.Fatalf("expected Old, got %v", old["title"])
+	}
+
+	commit := mustPOSTJSON(t, client, "http://test/api/tx/"+txID+"/commit", nil)
+	if commit.StatusCode() != fasthttp.StatusOK {
+		t.Fatalf("commit failed")
+	}
+
+	grAfter := mustGET(t, client, "http://test/api/articles/"+id)
+	var updated map[string]any
+	_ = json.Unmarshal(grAfter.Body(), &updated)
+	if updated["title"] != "New" {
+		t.Fatalf("expected New, got %v", updated["title"])
+	}
+}
+
+func TestTransactions_DeleteInsideTransaction(t *testing.T) {
+	client, stop := startTestServer(t)
+	defer stop()
+
+	c1 := mustPOSTJSON(t, client, "http://test/api/items", map[string]any{"name": "A"})
+	var m1 map[string]any
+	_ = json.Unmarshal(c1.Body(), &m1)
+	id := m1["id"].(string)
+
+	begin := mustPOSTJSON(t, client, "http://test/api/tx/begin", nil)
+	var out map[string]any
+	_ = json.Unmarshal(begin.Body(), &out)
+	txID := out["transaction_id"].(string)
+
+	del := mustDELETE(t, client, "http://test/api/tx/"+txID+"/entity/items/"+id)
+	if del.StatusCode() != fasthttp.StatusOK {
+		t.Fatalf("delete failed %d", del.StatusCode())
+	}
+
+	grBefore := mustGET(t, client, "http://test/api/items/"+id)
+	if string(grBefore.Body()) == "null" {
+		t.Fatalf("deleted before commit")
+	}
+
+	commit := mustPOSTJSON(t, client, "http://test/api/tx/"+txID+"/commit", nil)
+	if commit.StatusCode() != fasthttp.StatusOK {
+		t.Fatalf("commit failed")
+	}
+
+	grAfter := mustGET(t, client, "http://test/api/items/"+id)
+	if string(grAfter.Body()) != "null" {
+		t.Fatalf("expected null, got %s", grAfter.Body())
+	}
+}
+
+func TestTransactions_Rollback(t *testing.T) {
+	client, stop := startTestServer(t)
+	defer stop()
+
+	begin := mustPOSTJSON(t, client, "http://test/api/tx/begin", nil)
+	var out map[string]any
+	_ = json.Unmarshal(begin.Body(), &out)
+	txID := out["transaction_id"].(string)
+
+	w := mustPOSTJSON(t, client, "http://test/api/tx/"+txID+"/entity/users", map[string]any{
+		"name": "X",
+	})
+	if w.StatusCode() != fasthttp.StatusOK {
+		t.Fatalf("write failed")
+	}
+
+	rb := mustPOSTJSON(t, client, "http://test/api/tx/"+txID+"/rollback", nil)
+	if rb.StatusCode() != fasthttp.StatusOK {
+		t.Fatalf("rollback failed")
+	}
+
+	list := mustGET(t, client, "http://test/api/users")
+	var arr []map[string]any
+	_ = json.Unmarshal(list.Body(), &arr)
+	if len(arr) != 0 {
+		t.Fatalf("rollback did not cancel writes")
+	}
+}
+
+func TestTransactions_SchemaValidationInsideTransaction(t *testing.T) {
+	client, stop := startTestServer(t)
+	defer stop()
+
+	cfg := globals.GetConfig()
+	cfg.Api.Schema.Enabled = true
+	globals.SetConfig(cfg)
+
+	begin := mustPOSTJSON(t, client, "http://test/api/tx/begin", nil)
+	var out map[string]any
+	_ = json.Unmarshal(begin.Body(), &out)
+	txID := out["transaction_id"].(string)
+
+	ok1 := mustPOSTJSON(t, client, "http://test/api/tx/"+txID+"/entity/users", map[string]any{
+		"name": "Alice",
+		"age":  25,
+	})
+	if ok1.StatusCode() != fasthttp.StatusOK {
+		t.Fatalf("valid write rejected")
+	}
+
+	bad := mustPOSTJSON(t, client, "http://test/api/tx/"+txID+"/entity/users", map[string]any{
+		"name": 123,
+	})
+	if bad.StatusCode() == fasthttp.StatusOK {
+		t.Fatalf("invalid schema accepted")
+	}
+}
+
+func TestTransactions_SubEntitiesInsideTransaction(t *testing.T) {
+	client, stop := startTestServer(t)
+	defer stop()
+
+	begin := mustPOSTJSON(t, client, "http://test/api/tx/begin", nil)
+	var o map[string]any
+	_ = json.Unmarshal(begin.Body(), &o)
+	txID := o["transaction_id"].(string)
+
+	resp := mustPOSTJSON(t, client, "http://test/api/tx/"+txID+"/entity/articles", map[string]any{
+		"title": "Nested",
+		"author": map[string]any{
+			"@entity":  "author",
+			"fullname": "Taymour",
+		},
+	})
+	if resp.StatusCode() != fasthttp.StatusOK {
+		t.Fatalf("unexpected status %d", resp.StatusCode())
+	}
+
+	commit := mustPOSTJSON(t, client, "http://test/api/tx/"+txID+"/commit", nil)
+	if commit.StatusCode() != fasthttp.StatusOK {
+		t.Fatalf("commit failed")
+	}
+
+	list := mustGET(t, client, "http://test/api/author")
+	var authors []map[string]any
+	_ = json.Unmarshal(list.Body(), &authors)
+	if len(authors) != 1 {
+		t.Fatalf("expected 1 author, got %v", authors)
+	}
+}
+
+func TestTransactions_VisibilityAfterCommit(t *testing.T) {
+	client, stop := startTestServer(t)
+	defer stop()
+
+	begin := mustPOSTJSON(t, client, "http://test/api/tx/begin", nil)
+	var o map[string]any
+	_ = json.Unmarshal(begin.Body(), &o)
+	txID := o["transaction_id"].(string)
+
+	mustPOSTJSON(t, client, "http://test/api/tx/"+txID+"/entity/posts", map[string]any{
+		"title": "Hello",
+	})
+
+	before := mustGET(t, client, "http://test/api/posts")
+	var b []map[string]any
+	_ = json.Unmarshal(before.Body(), &b)
+	if len(b) != 0 {
+		t.Fatalf("visible before commit")
+	}
+
+	commit := mustPOSTJSON(t, client, "http://test/api/tx/"+txID+"/commit", nil)
+	if commit.StatusCode() != fasthttp.StatusOK {
+		t.Fatalf("commit failed")
+	}
+
+	after := mustGET(t, client, "http://test/api/posts")
+	var a []map[string]any
+	_ = json.Unmarshal(after.Body(), &a)
+	if len(a) != 1 {
+		t.Fatalf("expected 1 after commit")
+	}
+}
+
+func TestTransactions_MultipleOperationsInOrder(t *testing.T) {
+	client, stop := startTestServer(t)
+	defer stop()
+
+	begin := mustPOSTJSON(t, client, "http://test/api/tx/begin", nil)
+	var o map[string]any
+	_ = json.Unmarshal(begin.Body(), &o)
+	txID := o["transaction_id"].(string)
+
+	mustPOSTJSON(t, client, "http://test/api/tx/"+txID+"/entity/x", map[string]any{
+		"v": 1,
+	})
+	mustPOSTJSON(t, client, "http://test/api/tx/"+txID+"/entity/x", map[string]any{
+		"v": 2,
+	})
+
+	commit := mustPOSTJSON(t, client, "http://test/api/tx/"+txID+"/commit", nil)
+	if commit.StatusCode() != fasthttp.StatusOK {
+		t.Fatalf("commit failed")
+	}
+
+	all := mustGET(t, client, "http://test/api/x")
+	var arr []map[string]any
+	_ = json.Unmarshal(all.Body(), &arr)
+	if len(arr) != 2 {
+		t.Fatalf("expected 2, got %v", arr)
+	}
+}

--- a/test/internal/transaction_test/transaction_test.go
+++ b/test/internal/transaction_test/transaction_test.go
@@ -1,0 +1,214 @@
+package transaction_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/taymour/elysiandb/internal/schema"
+	"github.com/taymour/elysiandb/internal/transaction"
+)
+
+type fakeStorage struct {
+	writeErr    bool
+	updateFail  bool
+	deleteHit   bool
+	writeCount  int
+	updateCount int
+}
+
+func (f *fakeStorage) WriteEntity(entity string, data map[string]interface{}) []schema.ValidationError {
+	if f.writeErr {
+		return []schema.ValidationError{{Message: "x"}}
+	}
+	f.writeCount++
+	return nil
+}
+
+func (f *fakeStorage) UpdateEntityById(entity, id string, data map[string]interface{}) map[string]interface{} {
+	if f.updateFail {
+		return nil
+	}
+	f.updateCount++
+	return map[string]interface{}{"ok": true}
+}
+
+func (f *fakeStorage) DeleteEntityById(entity, id string) {
+	f.deleteHit = true
+}
+
+func TestBeginTransaction(t *testing.T) {
+	tx := transaction.BeginTransaction()
+	if tx == nil {
+		t.Fatalf("nil tx")
+	}
+	if tx.ID == "" {
+		t.Fatalf("empty id")
+	}
+}
+
+func TestGetTransaction_OK(t *testing.T) {
+	tx := transaction.BeginTransaction()
+	got, err := transaction.GetTransaction(tx.ID)
+	if err != nil {
+		t.Fatalf("unexpected err %v", err)
+	}
+	if got.ID != tx.ID {
+		t.Fatalf("wrong tx")
+	}
+}
+
+func TestGetTransaction_NotFound(t *testing.T) {
+	_, err := transaction.GetTransaction("missing")
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+}
+
+func TestAddOperation_OK(t *testing.T) {
+	tx := transaction.BeginTransaction()
+	op := transaction.TxOperation{
+		Kind:   "write",
+		Entity: "x",
+		Data:   map[string]interface{}{"a": 1},
+	}
+	err := transaction.AddOperation(tx.ID, op)
+	if err != nil {
+		t.Fatalf("unexpected err %v", err)
+	}
+	got, _ := transaction.GetTransaction(tx.ID)
+	if len(got.Ops) != 1 {
+		t.Fatalf("op not added")
+	}
+}
+
+func TestAddOperation_NotFound(t *testing.T) {
+	err := transaction.AddOperation("missing", transaction.TxOperation{})
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+}
+
+func TestRollbackTransaction_OK(t *testing.T) {
+	tx := transaction.BeginTransaction()
+	err := transaction.RollbackTransaction(tx.ID)
+	if err != nil {
+		t.Fatalf("unexpected err %v", err)
+	}
+	_, err = transaction.GetTransaction(tx.ID)
+	if err == nil {
+		t.Fatalf("should be removed")
+	}
+}
+
+func TestRollbackTransaction_NotFound(t *testing.T) {
+	err := transaction.RollbackTransaction("missing")
+	if err != nil {
+		t.Fatalf("unexpected err")
+	}
+}
+
+func TestCommitTransaction_WriteValidationFails(t *testing.T) {
+	f := &fakeStorage{writeErr: true}
+	orig := transaction.StorageImpl()
+	transaction.SetStorageImpl(f)
+	defer transaction.SetStorageImpl(orig)
+
+	tx := transaction.BeginTransaction()
+	transaction.AddOperation(tx.ID, transaction.TxOperation{
+		Kind:   "write",
+		Entity: "x",
+		Data:   map[string]interface{}{"a": 1},
+	})
+
+	err := transaction.CommitTransaction(tx.ID)
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+}
+
+func TestCommitTransaction_UpdateFails(t *testing.T) {
+	f := &fakeStorage{updateFail: true}
+	orig := transaction.StorageImpl()
+	transaction.SetStorageImpl(f)
+	defer transaction.SetStorageImpl(orig)
+
+	tx := transaction.BeginTransaction()
+	transaction.AddOperation(tx.ID, transaction.TxOperation{
+		Kind:   "update",
+		Entity: "x",
+		ID:     "1",
+		Data:   map[string]interface{}{"a": 1},
+	})
+
+	err := transaction.CommitTransaction(tx.ID)
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+}
+
+func TestCommitTransaction_Delete_OK(t *testing.T) {
+	f := &fakeStorage{}
+	orig := transaction.StorageImpl()
+	transaction.SetStorageImpl(f)
+	defer transaction.SetStorageImpl(orig)
+
+	tx := transaction.BeginTransaction()
+	transaction.AddOperation(tx.ID, transaction.TxOperation{
+		Kind:   "delete",
+		Entity: "x",
+		ID:     "1",
+	})
+
+	err := transaction.CommitTransaction(tx.ID)
+	if err != nil {
+		t.Fatalf("unexpected err %v", err)
+	}
+	if !f.deleteHit {
+		t.Fatalf("delete not called")
+	}
+}
+
+func TestCommitTransaction_NotFound(t *testing.T) {
+	err := transaction.CommitTransaction("missing")
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+}
+
+func TestCommitTransaction_WriteAndUpdate_Success(t *testing.T) {
+	f := &fakeStorage{}
+	orig := transaction.StorageImpl()
+	transaction.SetStorageImpl(f)
+	defer transaction.SetStorageImpl(orig)
+
+	tx := transaction.BeginTransaction()
+	transaction.AddOperation(tx.ID, transaction.TxOperation{
+		Kind:   "write",
+		Entity: "a",
+		Data:   map[string]interface{}{"x": 1},
+	})
+	transaction.AddOperation(tx.ID, transaction.TxOperation{
+		Kind:   "update",
+		Entity: "a",
+		ID:     "1",
+		Data:   map[string]interface{}{"y": 2},
+	})
+
+	err := transaction.CommitTransaction(tx.ID)
+	if err != nil {
+		t.Fatalf("unexpected err %v", err)
+	}
+
+	if f.writeCount != 1 || f.updateCount != 1 {
+		t.Fatalf("ops not called correctly")
+	}
+}
+
+func TestGenerateTxID(t *testing.T) {
+	id := time.Now().Format("20060102150405.000000000")
+	_ = id
+	got := transaction.BeginTransaction()
+	if got.ID == "" {
+		t.Fatalf("missing id")
+	}
+}


### PR DESCRIPTION
## Transaction System Summary

ElysianDB introduces a lightweight in-memory transaction system for the REST API. A transaction allows clients to queue multiple write, update, and delete operations without affecting the live datastore until explicitly committed.

### Key Characteristics

* **Isolated operations**: Changes are staged and invisible to readers until commit.
* **Atomic application**: All queued operations are applied sequentially. If any operation fails (validation, update on a missing entity, etc.), the entire commit is aborted.
* **Rollback support**: A transaction can be discarded at any time.
* **Schema validation included**: Write and update operations inside a transaction are validated against automatic or manual schemas.

### Endpoints

* `POST /api/tx/begin`: Start a new transaction and receive a transaction ID.
* `POST /api/tx/{txId}/entity/{entity}`: Queue a write operation.
* `PUT /api/tx/{txId}/entity/{entity}/{id}`: Queue an update operation.
* `DELETE /api/tx/{txId}/entity/{entity}/{id}`: Queue a delete operation.
* `POST /api/tx/{txId}/commit`: Apply all staged operations.
* `POST /api/tx/{txId}/rollback`: Cancel all staged operations.

### Benefits

* Enables batching and atomic multi-step updates
* Provides a safe staging mechanism before applying data modifications
* Maintains simplicity and predictable behavior

This first implementation focuses on clarity and correctness while offering a foundation for future extensions such as nested transactions or transaction previews.

Closes https://github.com/elysiandb/elysiandb/issues/109