### PR TITLE
Added token-based authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ No schema files. No migrations. No ORMs. Just start and query.
 * Protocols — HTTP REST, TCP (Redis-style text protocol)
 * High performance — minimal allocations and cache-friendly design
 * Transactions - basic transactions and atomic operations
-* Built-in Authentication — optional HTTP Basic authentication with salted bcrypt hashing
+* Built-in Authentication — optional HTTP Basic authentication with salted bcrypt hashing or Token based authentication
 
 ---
 
@@ -123,7 +123,8 @@ stats:
 security:
   authentication:
     enabled: false
-    mode: basic
+    mode: token
+    token: "your_secure_token"
 api:
   index:
     workers: 4

--- a/docker/elysian.yaml
+++ b/docker/elysian.yaml
@@ -12,6 +12,11 @@ log:
   flushIntervalSeconds: 5
 stats:
   enabled: false
+security:
+  authentication:
+    enabled: false
+    mode: token
+    token: "your_secure_token_here"
 api:
   index:
     workers: 4

--- a/docs/index.md
+++ b/docs/index.md
@@ -466,35 +466,45 @@ Using `includes=all` expands all linked entities recursively.
 
 ## Authentication
 
-ElysianDB supports optional HTTP Basic authentication to protect all REST and KV endpoints.
+ElysianDB supports optional authentication to protect all REST and KV endpoints. Two modes are available: `basic` and `token`.
 
 ### Configuration
 
 Enable authentication in your `elysian.yaml`:
 
 ```yaml
-security:
-  authentication:
-    enabled: true
-    mode: basic
+authentication:
+  enabled: true
+  mode: basic   # basic or token
 ```
 
 If `enabled` is false, all endpoints are publicly accessible.
 
+When using `token` mode, define a token:
+
+```yaml
+authentication:
+  enabled: true
+  mode: token
+  token: my-secret-token
+```
+
 ---
 
-## User Management
+## User Management (Basic Auth)
 
-Users are stored in the `users.json` file inside the configured `store.folder` directory.
-Passwords are hashed with bcrypt and salted using a server-generated key stored in `users.key`.
+When running in `basic` mode, users are stored in the `users.json` file inside the configured `store.folder` directory.
+Passwords are hashed with bcrypt after combining them with a server-generated secret stored in `users.key`.
+
+Both files are automatically created when needed.
 
 ---
 
 ## Client Usage
 
-All requests must include an `Authorization` header.
+### Basic Authentication
 
-Format:
+All requests must include an `Authorization` header:
 
 ```
 Authorization: Basic base64(username:password)
@@ -506,10 +516,32 @@ Example for `admin:secret`:
 Authorization: Basic YWRtaW46c2VjcmV0
 ```
 
-### curl
+### Token Authentication
+
+When using token mode:
+
+```
+Authorization: Bearer your-token
+```
+
+Example:
+
+```
+Authorization: Bearer my-secret-token
+```
+
+### curl Examples
+
+Basic auth:
 
 ```bash
 curl -u admin:secret http://localhost:8089/api
+```
+
+token auth:
+
+```bash
+curl -H "Authorization: Bearer my-secret-token" http://localhost:8089/api
 ```
 
 ---
@@ -530,9 +562,10 @@ Requests without authentication headers are rejected when authentication is enab
 
 * Passwords are never stored in plaintext
 * Hashing is done using bcrypt
-* A per-instance secret key is used as a salt
-* Deleting `users.key` invalidates all existing passwords
+* A per-instance secret key is used as part of the hashing process
+* Deleting `users.key` invalidates all stored password hashes
 * Deleting `users.json` removes all users
+* In `token` mode, anyone with the token can fully access the API
 
 ---
 

--- a/elysian.yaml
+++ b/elysian.yaml
@@ -12,8 +12,9 @@ stats:
   enabled: false
 security:
   authentication:
-    enabled: false
-    mode: basic
+    enabled: true
+    mode: token
+    token: "your_secure_token_here"
 api:
   schema:
     enabled: true

--- a/elysiandb.go
+++ b/elysiandb.go
@@ -28,9 +28,10 @@ func main() {
 
 	cfg, err := configuration.LoadConfig(*configFilename)
 	if err != nil {
-		log.Error("Error loading config:", err)
+		log.DirectError("Error loading config:", err)
 		return
 	}
+
 	globals.SetConfig(cfg)
 
 	args := os.Args

--- a/internal/configuration/loader.go
+++ b/internal/configuration/loader.go
@@ -15,6 +15,7 @@ type SecurityConfig struct {
 type AuthenticationConfig struct {
 	Enabled bool   `yaml:"enabled"`
 	Mode    string `yaml:"mode"`
+	Token   string `yaml:"token"`
 }
 
 type Config struct {
@@ -89,6 +90,12 @@ func LoadConfig(path string) (*Config, error) {
 	if err := yaml.Unmarshal(data, &cfg); err != nil {
 		log.Fatal("error:", err)
 		return nil, err
+	}
+
+	if cfg.Security.Authentication.Enabled && cfg.Security.Authentication.Mode == "token" {
+		if cfg.Security.Authentication.Token == "" {
+			return nil, fmt.Errorf("token authentication is enabled but no token is provided in the configuration")
+		}
 	}
 
 	return &cfg, nil

--- a/internal/log/log.go
+++ b/internal/log/log.go
@@ -31,6 +31,10 @@ func DirectInfo(args ...interface{}) {
 	directLog("INFO", cyan, args...)
 }
 
+func DirectError(args ...interface{}) {
+	directLog("ERROR", red, args...)
+}
+
 func Success(args ...interface{}) {
 	go log("SUCCESS", green, args...)
 }

--- a/internal/security/authentication.go
+++ b/internal/security/authentication.go
@@ -15,6 +15,11 @@ func BasicAuthenticationIsEnabled() bool {
 	return cfg.Security.Authentication.Enabled && cfg.Security.Authentication.Mode == "basic"
 }
 
+func TokenAuthenticationIsEnabled() bool {
+	cfg := globals.GetConfig()
+	return cfg.Security.Authentication.Enabled && cfg.Security.Authentication.Mode == "token"
+}
+
 func Authenticate(requestHandler fasthttp.RequestHandler) fasthttp.RequestHandler {
 	return func(ctx *fasthttp.RequestCtx) {
 		if !AuthenticationIsEnabled() {
@@ -23,6 +28,11 @@ func Authenticate(requestHandler fasthttp.RequestHandler) fasthttp.RequestHandle
 		}
 
 		if BasicAuthenticationIsEnabled() && !CheckBasicAuthentication(ctx) {
+			ctx.Response.SetStatusCode(fasthttp.StatusUnauthorized)
+			return
+		}
+
+		if TokenAuthenticationIsEnabled() && !CheckTokenAuthentication(ctx) {
 			ctx.Response.SetStatusCode(fasthttp.StatusUnauthorized)
 			return
 		}

--- a/internal/security/token.go
+++ b/internal/security/token.go
@@ -1,0 +1,25 @@
+package security
+
+import (
+	"github.com/taymour/elysiandb/internal/globals"
+	"github.com/valyala/fasthttp"
+)
+
+var CheckTokenAuthentication = func(ctx *fasthttp.RequestCtx) bool {
+	cfg := globals.GetConfig()
+	expectedToken := cfg.Security.Authentication.Token
+
+	providedToken := string(ctx.Request.Header.Peek("Authorization"))
+	if providedToken == "" {
+		return false
+	}
+
+	const bearerPrefix = "Bearer "
+	if len(providedToken) <= len(bearerPrefix) || providedToken[:len(bearerPrefix)] != bearerPrefix {
+		return false
+	}
+
+	providedToken = providedToken[len(bearerPrefix):]
+
+	return providedToken == expectedToken
+}

--- a/test/internal/security_test/authentication_test.go
+++ b/test/internal/security_test/authentication_test.go
@@ -1,0 +1,121 @@
+package security_test
+
+import (
+	"testing"
+
+	"github.com/taymour/elysiandb/internal/configuration"
+	"github.com/taymour/elysiandb/internal/globals"
+	"github.com/taymour/elysiandb/internal/security"
+	"github.com/valyala/fasthttp"
+)
+
+func TestAuthenticate_NoAuthentication(t *testing.T) {
+	globals.SetConfig(&configuration.Config{})
+	globals.GetConfig().Security.Authentication.Enabled = false
+
+	called := false
+	handler := security.Authenticate(func(ctx *fasthttp.RequestCtx) {
+		called = true
+	})
+
+	ctx := &fasthttp.RequestCtx{}
+	handler(ctx)
+
+	if !called {
+		t.Fatalf("handler should be called when authentication disabled")
+	}
+}
+
+func TestAuthenticate_BasicAuth_Success(t *testing.T) {
+	globals.SetConfig(&configuration.Config{})
+	globals.GetConfig().Security.Authentication.Enabled = true
+	globals.GetConfig().Security.Authentication.Mode = "basic"
+
+	ctx := &fasthttp.RequestCtx{}
+	called := false
+
+	orig := security.CheckBasicAuthentication
+	security.CheckBasicAuthentication = func(c *fasthttp.RequestCtx) bool { return true }
+	defer func() { security.CheckBasicAuthentication = orig }()
+
+	handler := security.Authenticate(func(c *fasthttp.RequestCtx) {
+		called = true
+	})
+
+	handler(ctx)
+
+	if !called {
+		t.Fatalf("handler should be called when basic auth succeeds")
+	}
+}
+
+func TestAuthenticate_BasicAuth_Fail(t *testing.T) {
+	globals.SetConfig(&configuration.Config{})
+	globals.GetConfig().Security.Authentication.Enabled = true
+	globals.GetConfig().Security.Authentication.Mode = "basic"
+
+	ctx := &fasthttp.RequestCtx{}
+	called := false
+
+	orig := security.CheckBasicAuthentication
+	security.CheckBasicAuthentication = func(c *fasthttp.RequestCtx) bool { return false }
+	defer func() { security.CheckBasicAuthentication = orig }()
+
+	handler := security.Authenticate(func(c *fasthttp.RequestCtx) {
+		called = true
+	})
+
+	handler(ctx)
+
+	if called {
+		t.Fatalf("handler should not be called when basic auth fails")
+	}
+	if ctx.Response.StatusCode() != fasthttp.StatusUnauthorized {
+		t.Fatalf("expected 401 unauthorized")
+	}
+}
+
+func TestAuthenticate_TokenAuth_Success(t *testing.T) {
+	globals.SetConfig(&configuration.Config{})
+	globals.GetConfig().Security.Authentication.Enabled = true
+	globals.GetConfig().Security.Authentication.Mode = "token"
+	globals.GetConfig().Security.Authentication.Token = "secret123"
+
+	ctx := &fasthttp.RequestCtx{}
+	ctx.Request.Header.Set("Authorization", "Bearer secret123")
+	called := false
+
+	handler := security.Authenticate(func(c *fasthttp.RequestCtx) {
+		called = true
+	})
+
+	handler(ctx)
+
+	if !called {
+		t.Fatalf("handler should be called when token auth succeeds")
+	}
+}
+
+func TestAuthenticate_TokenAuth_Fail(t *testing.T) {
+	globals.SetConfig(&configuration.Config{})
+	globals.GetConfig().Security.Authentication.Enabled = true
+	globals.GetConfig().Security.Authentication.Mode = "token"
+	globals.GetConfig().Security.Authentication.Token = "secret123"
+
+	ctx := &fasthttp.RequestCtx{}
+	ctx.Request.Header.Set("Authorization", "Bearer wrong")
+	called := false
+
+	handler := security.Authenticate(func(c *fasthttp.RequestCtx) {
+		called = true
+	})
+
+	handler(ctx)
+
+	if called {
+		t.Fatalf("handler should not be called when token auth fails")
+	}
+	if ctx.Response.StatusCode() != fasthttp.StatusUnauthorized {
+		t.Fatalf("expected 401 unauthorized")
+	}
+}

--- a/test/internal/security_test/token_test.go
+++ b/test/internal/security_test/token_test.go
@@ -1,0 +1,63 @@
+package security_test
+
+import (
+	"testing"
+
+	"github.com/taymour/elysiandb/internal/globals"
+	"github.com/taymour/elysiandb/internal/security"
+	"github.com/valyala/fasthttp"
+)
+
+func TestCheckTokenAuthentication_ValidToken(t *testing.T) {
+	globals.GetConfig().Security.Authentication.Token = "secret123"
+
+	ctx := &fasthttp.RequestCtx{}
+	ctx.Request.Header.Set("Authorization", "Bearer secret123")
+
+	if !security.CheckTokenAuthentication(ctx) {
+		t.Fatalf("expected authentication to succeed")
+	}
+}
+
+func TestCheckTokenAuthentication_InvalidToken(t *testing.T) {
+	globals.GetConfig().Security.Authentication.Token = "secret123"
+
+	ctx := &fasthttp.RequestCtx{}
+	ctx.Request.Header.Set("Authorization", "Bearer wrong")
+
+	if security.CheckTokenAuthentication(ctx) {
+		t.Fatalf("expected authentication to fail with invalid token")
+	}
+}
+
+func TestCheckTokenAuthentication_MissingHeader(t *testing.T) {
+	globals.GetConfig().Security.Authentication.Token = "secret123"
+
+	ctx := &fasthttp.RequestCtx{}
+
+	if security.CheckTokenAuthentication(ctx) {
+		t.Fatalf("expected authentication to fail without header")
+	}
+}
+
+func TestCheckTokenAuthentication_NoBearerPrefix(t *testing.T) {
+	globals.GetConfig().Security.Authentication.Token = "secret123"
+
+	ctx := &fasthttp.RequestCtx{}
+	ctx.Request.Header.Set("Authorization", "Token secret123")
+
+	if security.CheckTokenAuthentication(ctx) {
+		t.Fatalf("expected authentication to fail without Bearer prefix")
+	}
+}
+
+func TestCheckTokenAuthentication_EmptyToken(t *testing.T) {
+	globals.GetConfig().Security.Authentication.Token = ""
+
+	ctx := &fasthttp.RequestCtx{}
+	ctx.Request.Header.Set("Authorization", "Bearer ")
+
+	if security.CheckTokenAuthentication(ctx) {
+		t.Fatalf("expected authentication to fail when expected token is empty")
+	}
+}


### PR DESCRIPTION
Adds token-based authentication to ElysianDB alongside the existing Basic authentication mode. The update introduces configuration support for `mode: token` and a dedicated bearer token validation mechanism. This enhancement allows clients to authenticate using either Basic credentials or a secure static token, improving flexibility and integration options.


Closes https://github.com/elysiandb/elysiandb/issues/115