### PR TITLE
Added CRUD for users in api & adminui

### DIFF
--- a/adminui/src/App.css
+++ b/adminui/src/App.css
@@ -89,6 +89,15 @@ button.navbar-toggler {
     border-color: rgba(255,255,255,0.2) !important;
 }
 
+.navbar-hello {
+    display: flex;
+    align-items: center;
+    font-size: 1rem;
+    font-weight: 500;
+    color: var(--text-dim);
+    line-height: 1;
+}
+
 /* -----------------------------------
    CARDS
 ----------------------------------- */
@@ -114,7 +123,7 @@ button.navbar-toggler {
 
 .toast-container {
     position: fixed;
-    top: 20px;
+    top: 13px;
     right: 20px;
     z-index: 99999;
     display: flex;
@@ -202,6 +211,78 @@ button.navbar-toggler {
 .modal-body input::placeholder {
     color: rgba(230,230,240,0.35) !important;
 }
+
+.modal-body label {
+    color: var(--text-dim);
+    font-size: 0.85rem;
+    margin-bottom: 6px;
+}
+
+.modal-body .form-control,
+.modal-body .form-select {
+    background: rgba(255,255,255,0.08) !important;
+    border: 1px solid rgba(255,255,255,0.18) !important;
+    color: var(--text-main) !important;
+    border-radius: 10px !important;
+    padding: 10px 14px !important;
+}
+
+.modal-body .form-control:focus,
+.modal-body .form-select:focus {
+    border-color: var(--accent) !important;
+    box-shadow: 0 0 0 2px rgba(247,214,74,0.25) !important;
+    background: rgba(255,255,255,0.1) !important;
+}
+
+.modal-body .form-select {
+    width: 100% !important;
+    height: 44px;
+    background: var(--bg-glass) !important;
+    border: 1px solid rgba(255,255,255,0.25) !important;
+    border-radius: 6px !important;
+    color: var(--text-main) !important;
+    padding-right: 34px !important;
+    padding-left: 14px !important;
+    appearance: none !important;
+    -webkit-appearance: none !important;
+    -moz-appearance: none !important;
+    background-image: url("data:image/svg+xml;charset=UTF-8,%3Csvg width='14' height='14' viewBox='0 0 20 20' fill='%23e6e6f0' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M5.516 7.548L10 12.032l4.484-4.484' stroke='%23e6e6f0' stroke-width='2' stroke-linecap='round'/%3E%3C/svg%3E") !important;
+    background-repeat: no-repeat !important;
+    background-position: right 10px center !important;
+    background-size: 14px 14px !important;
+}
+
+.modal-body .form-select:focus {
+    border-color: var(--accent) !important;
+    box-shadow: 0 0 0 2px rgba(247,214,74,0.25) !important;
+    outline: none !important;
+}
+
+.modal-body .form-select option {
+    background: var(--bg-section);
+    color: var(--text-main);
+}
+
+.modal-footer .btn {
+    min-width: 90px;
+}
+
+.modal-footer .btn-primary {
+    background: rgba(247,214,74,0.18) !important;
+    border-color: var(--accent) !important;
+    color: var(--accent) !important;
+}
+
+.modal-footer .btn-primary:hover {
+    background: rgba(247,214,74,0.28) !important;
+    color: #000 !important;
+}
+
+.modal-backdrop.show {
+    opacity: 0.55;
+    backdrop-filter: blur(6px);
+}
+
 
 .btn-close {
     width: 32px !important;
@@ -463,4 +544,103 @@ button:hover, .btn:hover {
     margin-left: 18px;
     padding-left: 10px;
     border-left: 1px dashed rgba(255,255,255,0.15);
+}
+
+/* -----------------------------------
+   USERS TABLE — GLASS / ENTITIES STYLE
+----------------------------------- */
+
+.users-table {
+    border-collapse: collapse;
+    overflow: hidden;
+    box-shadow: var(--shadow);
+    background: var(--bg-card) !important;
+    border-radius: var(--radius) !important;
+    border: 1px solid rgba(255, 255, 255, .06) !important;
+    -webkit-backdrop-filter: blur(18px) saturate(160%);
+    backdrop-filter: blur(18px) saturate(160%);
+}
+
+.users-table thead th {
+    padding: 18px 26px;
+    background: var(--bg-card);
+    color: var(--accent);
+    font-weight: 600;
+    font-size: 0.9rem;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    border-bottom: 1px solid rgba(255,255,255,0.08);
+}
+
+.users-table tbody td {
+    padding: 18px 26px;
+    background: #0c1022;
+    color: var(--text-main);
+    border-bottom: 1px solid rgba(255,255,255,0.06);
+}
+
+.users-table tbody tr:nth-child(2n) td {
+    background: var(--bg-card);
+}
+
+.users-table tbody tr:last-child td {
+    border-bottom: none;
+}
+
+.users-table tbody tr:hover td {
+    background: rgba(247,214,74,0.12);
+    color: var(--accent);
+}
+
+.users-table .table-actions {
+    display: flex;
+    gap: 14px;
+}
+
+.users-table .btn {
+    padding: 6px 18px;
+    border-radius: 12px;
+    background: rgba(40,46,80,0.95);
+    border: 1px solid rgba(255,255,255,0.12);
+    color: var(--text-main);
+    font-size: 0.85rem;
+    transition: 0.18s ease;
+}
+
+.users-table .btn:hover {
+    background: rgba(247,214,74,0.18);
+    border-color: var(--accent);
+    color: var(--accent);
+}
+
+.users-table .btn-danger {
+    color: #ffb1b1;
+    background: rgba(255,92,92,0.08);
+    border-color: rgba(255,92,92,0.35);
+}
+
+.users-table .btn-danger:hover {
+    background: rgba(255,92,92,0.18);
+    border-color: rgba(255,92,92,0.9);
+    color: #ffd6d6;
+}
+
+.users-search-input {
+    width: 260px !important;
+    background: rgba(255,255,255,0.08) !important;
+    border: 1px solid rgba(255,255,255,0.18) !important;
+    border-radius: 10px !important;
+    color: var(--text-main) !important;
+    padding: 8px 14px !important;
+}
+
+.users-search-input::placeholder {
+    color: rgba(230,230,240,0.35) !important;
+}
+
+.users-search-input:focus {
+    background: rgba(255,255,255,0.1) !important;
+    border-color: var(--accent) !important;
+    box-shadow: 0 0 0 2px rgba(247,214,74,0.25) !important;
+    outline: none !important;
 }

--- a/adminui/src/App.jsx
+++ b/adminui/src/App.jsx
@@ -6,6 +6,7 @@ import Configuration from "./pages/Configuration.tsx";
 import {AuthStatus, useAuth} from "./hooks/account/useAuth.ts";
 import {Login} from "./pages/Login.tsx";
 import EntityTypesList from "./pages/EntityTypesList.jsx";
+import UsersList from "./pages/UsersList.jsx";
 
 export default function App() {
 
@@ -43,9 +44,13 @@ export default function App() {
                     element: <Configuration />,
                 },
                 {
+                    path: "users",
+                    element: <UsersList />,
+                },
+                {
                     path: "entities",
                     element: <EntityTypesList />,
-                }
+                },
             ],
         },
     ]);

--- a/adminui/src/components/header/NavBar.jsx
+++ b/adminui/src/components/header/NavBar.jsx
@@ -3,7 +3,7 @@ import { NavLink } from "react-router-dom";
 import { useAuth } from "../../hooks/account/useAuth.ts";
 
 export default function NavBar() {
-    const { logout } = useAuth();
+    const { logout, account } = useAuth();
 
     return (
         <Navbar expand="lg" className="bg-body-tertiary">
@@ -26,6 +26,14 @@ export default function NavBar() {
 
                         <Nav.Link
                             as={NavLink}
+                            to="/admin/users"
+                            end
+                        >
+                            Users
+                        </Nav.Link>
+
+                        <Nav.Link
+                            as={NavLink}
                             to="/admin/entities"
                             end
                         >
@@ -35,7 +43,8 @@ export default function NavBar() {
                     </Nav>
                 </Navbar.Collapse>
 
-                <Nav>
+                <Nav className="align-items-center gap-3">
+                    <span className="navbar-hello">Hello {account?.username}</span>
                     <Button onClick={logout}>Logout</Button>
                 </Nav>
             </Container>

--- a/adminui/src/components/user/UserLine.jsx
+++ b/adminui/src/components/user/UserLine.jsx
@@ -1,0 +1,22 @@
+import { Button } from "react-bootstrap";
+
+export default function UserLine({ user, onChangePassword, onDeleted }) {
+    return (
+        <tr>
+            <td>{user.username}</td>
+            <td>{user.role}</td>
+            <td className="table-actions">
+                <Button size="sm" onClick={() => onChangePassword(user)}>
+                    Change password
+                </Button>
+                <Button
+                    size="sm"
+                    variant="danger"
+                    onClick={onDeleted}
+                >
+                    Delete
+                </Button>
+            </td>
+        </tr>
+    );
+}

--- a/adminui/src/components/user/UserModal.jsx
+++ b/adminui/src/components/user/UserModal.jsx
@@ -1,0 +1,94 @@
+import { Button, Form, Modal } from "react-bootstrap";
+import { useEffect, useState } from "react";
+import { useUsers } from "../../hooks/user/useUsers.js";
+import {useToast} from "../../hooks/notification/useToast.js";
+
+export default function UserModal({ showModal, onHide, user, onSaved }) {
+    const { show } = useToast();
+    const { createUser, changeUserPassword } = useUsers();
+
+    const [username, setUsername] = useState("");
+    const [password, setPassword] = useState("");
+    const [role, setRole] = useState("user");
+    const [saving, setSaving] = useState(false);
+
+    useEffect(() => {
+        if (user) {
+            setUsername(user.username);
+            setRole(user.role);
+        } else {
+            setUsername("");
+            setRole("user");
+        }
+        setPassword("");
+    }, [user, show]);
+
+    const handleSave = async () => {
+        setSaving(true);
+        try {
+            if (user) {
+                if (password) {
+                    await changeUserPassword(username, password);
+                }
+            } else {
+                await createUser({ username, password, role });
+            }
+
+            if (password === "") {
+                show("error", `Please enter a password.`);
+            } else {
+                onSaved();
+                onHide();
+            }
+        } finally {
+            setSaving(false);
+        }
+    };
+
+    return (
+        <Modal show={showModal} onHide={onHide} centered>
+            <Modal.Header closeButton>
+                <Modal.Title>{user ? "Edit user" : "Create user"}</Modal.Title>
+            </Modal.Header>
+            <Modal.Body>
+                <Form>
+                    <Form.Group className="mb-3">
+                        <Form.Label>Username</Form.Label>
+                        <Form.Control
+                            value={username}
+                            disabled={!!user}
+                            onChange={(e) => setUsername(e.target.value)}
+                        />
+                    </Form.Group>
+
+                    <Form.Group className="mb-3">
+                        <Form.Label>Password</Form.Label>
+                        <Form.Control
+                            type="password"
+                            value={password}
+                            onChange={(e) => setPassword(e.target.value)}
+                        />
+                    </Form.Group>
+
+                    {!user && (
+                        <Form.Group>
+                            <Form.Label>Role</Form.Label>
+                            <Form.Select value={role} onChange={(e) => setRole(e.target.value)}>
+                                <option value="admin">admin</option>
+                                <option value="user">user</option>
+                            </Form.Select>
+                        </Form.Group>
+                    )}
+                </Form>
+            </Modal.Body>
+            <Modal.Footer>
+                <Button variant="secondary" onClick={onHide}>
+                    Cancel
+                </Button>
+                <Button onClick={handleSave} disabled={saving}>
+                    Save
+                </Button>
+            </Modal.Footer>
+        </Modal>
+    );
+}

--- a/adminui/src/hooks/user/useUsers.js
+++ b/adminui/src/hooks/user/useUsers.js
@@ -1,0 +1,95 @@
+import {useCallback, useState} from "react";
+import {apiFetch} from "../../utils/api";
+import {useToast} from "../notification/useToast.js";
+
+export function useUsers() {
+    const { show } = useToast();
+    const [list, setList] = useState([]);
+    const [loading, setLoading] = useState(true);
+    const [error, setError] = useState(null);
+
+    const loadAll = useCallback(() => {
+        setLoading(true);
+
+        apiFetch("/api/security/user")
+            .then((response) => {
+                setList(response.users);
+                setLoading(false);
+            })
+            .catch((err) => {
+                setError(err);
+                setLoading(false);
+            });
+    }, []);
+
+    // const loadOne = useCallback((entityType) => {
+    //     setLoading(true);
+    //
+    //     apiFetch("/api/" + entityType + "/schema")
+    //         .then((response) => {
+    //             setEntityTypeData(response);
+    //
+    //             setLoading(false);
+    //         })
+    //         .catch((err) => {
+    //             setError(err);
+    //             setLoading(false);
+    //         });
+    // }, []);
+
+    const createUser = useCallback(async (user) => {
+        setLoading(true);
+
+        try {
+            await apiFetch(`/api/security/user`, {
+                method: "POST",
+                json: user,
+            });
+            show("success", `User created successfully`);
+        } catch (err) {
+            setError(err?.message ?? "Unknown error");
+            show("error", `Failed to create user`);
+            throw err;
+        } finally {
+            setLoading(null);
+        }
+    }, [show]);
+
+    const changeUserPassword = useCallback(async (username, password) => {
+        setLoading(true);
+
+        try {
+            await apiFetch(`/api/security/user/`+username+`/password`, {
+                method: "PUT",
+                json: {password: password},
+            });
+            show("success", `User's paswword successfully modified`);
+        } catch (err) {
+            setError(err?.message ?? "Unknown error");
+            show("error", `Failed to change user's password`);
+            throw err;
+        } finally {
+            setLoading(null);
+        }
+    }, [show]);
+
+    const deleteUser = useCallback(async (username, password) => {
+        setLoading(true);
+
+        try {
+            await apiFetch(`/api/security/user/`+username, {
+                method: "DELETE",
+                json: {password: password},
+            });
+            show("success", `User paswword successfully deleted`);
+        } catch (err) {
+            setError(err?.message ?? "Unknown error");
+            show("error", `Failed to delete user`);
+            throw err;
+        } finally {
+            setLoading(null);
+        }
+    }, [show]);
+
+    return { list, loading, error, loadAll, deleteUser, createUser, changeUserPassword };
+}

--- a/adminui/src/pages/EntityTypesList.jsx
+++ b/adminui/src/pages/EntityTypesList.jsx
@@ -82,7 +82,6 @@ export default function EntityTypesList() {
     return (
         <Container fluid className="py-4 entity-types-layout">
             <Row className="g-4">
-
                 <Col xs={3}>
                     <Card className="entity-sidebar">
                         <Card.Header className="text-warning fw-bold">

--- a/adminui/src/pages/UsersList.jsx
+++ b/adminui/src/pages/UsersList.jsx
@@ -1,0 +1,94 @@
+import { Button, Container, Row, Spinner, Table, Form } from "react-bootstrap";
+import { useEffect, useMemo, useState } from "react";
+import { useUsers } from "../hooks/user/useUsers.js";
+import UserLine from "../components/user/UserLine.jsx";
+import UserModal from "../components/user/UserModal.jsx";
+
+export default function UsersList() {
+    const { list, loadAll, loading, deleteUser } = useUsers();
+    const [showModal, setShowModal] = useState(false);
+    const [selectedUser, setSelectedUser] = useState(null);
+    const [search, setSearch] = useState("");
+
+    useEffect(() => {
+        loadAll();
+    }, [loadAll]);
+
+    const openCreate = () => {
+        setSelectedUser(null);
+        setShowModal(true);
+    };
+
+    const changePassword = (user) => {
+        setSelectedUser(user);
+        setShowModal(true);
+    };
+
+    const handleDelete = async (username) => {
+        if (!window.confirm(`Delete user "${username}" ?`)) return;
+        await deleteUser(username);
+        loadAll();
+    };
+
+    const filteredUsers = useMemo(() => {
+        if (!search.trim()) return list;
+        const q = search.toLowerCase();
+        return list.filter((u) => u.username.toLowerCase().includes(q));
+    }, [list, search]);
+
+    if (loading) {
+        return (
+            <Container className="py-5 text-center">
+                <Spinner animation="border" />
+            </Container>
+        );
+    }
+
+    return (
+        <Container fluid className="py-4 entity-types-layout">
+            <Row className="align-items-center mb-3">
+                <div className="d-flex justify-content-between align-items-center w-100">
+                    <Button size="sm" onClick={openCreate}>
+                        Create a user
+                    </Button>
+
+                    <Form.Control
+                        placeholder="Search user…"
+                        value={search}
+                        onChange={(e) => setSearch(e.target.value)}
+                        className="users-search-input"
+                    />
+                </div>
+            </Row>
+
+            <Row className="g-4 mt-1">
+                <Table className="users-table align-middle">
+                    <thead>
+                    <tr>
+                        <th>Username</th>
+                        <th>Role</th>
+                        <th>Actions</th>
+                    </tr>
+                    </thead>
+                    <tbody>
+                    {filteredUsers.map((user) => (
+                        <UserLine
+                            key={user.username}
+                            user={user}
+                            onChangePassword={changePassword}
+                            onDeleted={() => handleDelete(user.username)}
+                        />
+                    ))}
+                    </tbody>
+                </Table>
+            </Row>
+
+            <UserModal
+                showModal={showModal}
+                user={selectedUser}
+                onHide={() => setShowModal(false)}
+                onSaved={loadAll}
+            />
+        </Container>
+    );
+}

--- a/internal/api/storage.go
+++ b/internal/api/storage.go
@@ -182,6 +182,7 @@ func ListPublicEntityTypes() []string {
 func ReadEntityById(entity string, id string) map[string]interface{} {
 	key := globals.ApiSingleEntityKey(entity, id)
 	data, _ := storage.GetJsonByKey(key)
+
 	return data
 }
 

--- a/internal/routing/router.go
+++ b/internal/routing/router.go
@@ -6,6 +6,7 @@ import (
 	"github.com/taymour/elysiandb/internal/security"
 	http_adminui "github.com/taymour/elysiandb/internal/transport/http/adminui"
 	"github.com/taymour/elysiandb/internal/transport/http/api"
+	http_security "github.com/taymour/elysiandb/internal/transport/http/api/security"
 	api_transaction "github.com/taymour/elysiandb/internal/transport/http/api/transactions"
 	"github.com/taymour/elysiandb/internal/transport/http/controller"
 	"github.com/valyala/fasthttp"
@@ -56,6 +57,14 @@ func RegisterRoutes(r *router.Router) {
 	r.POST("/api/tx/{txId}/commit", Version(security.Authenticate(api_transaction.CommitTransactionController)))
 
 	r.GET("/config", Version(security.Authenticate(controller.GetConfigController)))
+
+	if security.AuthenticationIsEnabled() && security.UserAuthenticationIsEnabled() {
+		r.POST("/api/security/user", Version(http_adminui.AdminAuth(http_security.CreateUserController)))
+		r.GET("/api/security/user", Version(http_adminui.AdminAuth(http_security.GetUsersController)))
+		r.GET("/api/security/user/{user_name}", Version(http_adminui.AdminAuth(http_security.GetUserByUsernameController)))
+		r.DELETE("/api/security/user/{user_name}", Version(http_adminui.AdminAuth(http_security.DeleteUserByUsernameController)))
+		r.PUT("/api/security/user/{user_name}/password", Version(http_adminui.AdminAuth(http_security.ChangeUserPasswordController)))
+	}
 
 	if globals.GetConfig().AdminUI.Enabled {
 		r.POST("/admin/login", http_adminui.LoginController)

--- a/internal/security/basic_user.go
+++ b/internal/security/basic_user.go
@@ -169,6 +169,48 @@ func InitBasicUsersStorage() error {
 	return nil
 }
 
+func GetBasicUserByUsername(username string) (map[string]interface{}, error) {
+	err := InitBasicUsersStorage()
+	if err != nil {
+		return nil, err
+	}
+
+	u := api_storage.ReadEntityById(UserEntity, username)
+	if u == nil {
+		return nil, fmt.Errorf("user '%s' not found", username)
+	}
+
+	delete(u, "password")
+
+	return u, nil
+}
+
+func ListBasicUsers() ([]map[string]interface{}, error) {
+	err := InitBasicUsersStorage()
+	if err != nil {
+		return nil, err
+	}
+
+	users := api_storage.ListEntities(
+		UserEntity,
+		0,
+		0,
+		"username",
+		true,
+		nil,
+		"",
+		"",
+	)
+
+	result := make([]map[string]interface{}, 0, len(users))
+	for _, u := range users {
+		delete(u, "password")
+		result = append(result, u)
+	}
+
+	return result, nil
+}
+
 func CreateBasicUser(user *BasicUser) error {
 	err := InitBasicUsersStorage()
 	if err != nil {

--- a/internal/transport/http/api/security/change_user_password.go
+++ b/internal/transport/http/api/security/change_user_password.go
@@ -1,0 +1,39 @@
+package http_security
+
+import (
+	"encoding/json"
+
+	"github.com/taymour/elysiandb/internal/security"
+	"github.com/valyala/fasthttp"
+)
+
+var req struct {
+	Password string `json:"password"`
+}
+
+func ChangeUserPasswordController(ctx *fasthttp.RequestCtx) {
+	ctx.Response.Header.Set("Content-Type", "application/json")
+	username := ctx.UserValue("user_name").(string)
+
+	if canManage, err := security.CurrentUserCanManageUser(ctx, username); err != nil || !canManage {
+		ctx.SetStatusCode(fasthttp.StatusForbidden)
+		return
+	}
+
+	if err := json.Unmarshal(ctx.PostBody(), &req); err != nil {
+		ctx.SetStatusCode(fasthttp.StatusBadRequest)
+		ctx.SetBodyString(`{"error":"invalid request body"}`)
+		return
+	}
+
+	password := req.Password
+
+	err := security.ChangeUserPassword(username, password)
+	if err != nil {
+		ctx.SetStatusCode(fasthttp.StatusNotFound)
+		ctx.SetBodyString(`{"error":"` + err.Error() + `"}`)
+		return
+	}
+
+	ctx.SetStatusCode(fasthttp.StatusOK)
+}

--- a/internal/transport/http/api/security/create_user.go
+++ b/internal/transport/http/api/security/create_user.go
@@ -1,0 +1,49 @@
+package http_security
+
+import (
+	"encoding/json"
+
+	"github.com/taymour/elysiandb/internal/security"
+	"github.com/valyala/fasthttp"
+)
+
+type UserDto struct {
+	User     string `json:"username"`
+	Password string `json:"password"`
+	Role     string `json:"role"`
+}
+
+func (u *UserDto) ToBasicUser() *security.BasicUser {
+	return &security.BasicUser{
+		Username: u.User,
+		Password: u.Password,
+		Role:     security.Role(u.Role),
+	}
+}
+
+func CreateUserController(ctx *fasthttp.RequestCtx) {
+	ctx.Response.Header.Set("Content-Type", "application/json")
+
+	if !security.CurrentUserIsAdmin(ctx) {
+		ctx.SetStatusCode(fasthttp.StatusForbidden)
+		return
+	}
+
+	var user UserDto
+	if err := json.Unmarshal(ctx.PostBody(), &user); err != nil {
+		ctx.SetStatusCode(fasthttp.StatusBadRequest)
+		ctx.SetBodyString(`{"error":"invalid request body"}`)
+
+		return
+	}
+
+	err := security.CreateBasicUser(user.ToBasicUser())
+	if err != nil {
+		ctx.SetStatusCode(fasthttp.StatusNotFound)
+		ctx.SetBodyString(`{"error":"` + err.Error() + `"}`)
+
+		return
+	}
+
+	ctx.SetStatusCode(fasthttp.StatusOK)
+}

--- a/internal/transport/http/api/security/delete_user_by_username.go
+++ b/internal/transport/http/api/security/delete_user_by_username.go
@@ -1,0 +1,19 @@
+package http_security
+
+import (
+	"github.com/taymour/elysiandb/internal/security"
+	"github.com/valyala/fasthttp"
+)
+
+func DeleteUserByUsernameController(ctx *fasthttp.RequestCtx) {
+	ctx.Response.Header.Set("Content-Type", "application/json")
+	username := ctx.UserValue("user_name").(string)
+
+	if canManage, err := security.CurrentUserCanManageUser(ctx, username); err != nil || !canManage {
+		ctx.SetStatusCode(fasthttp.StatusForbidden)
+		return
+	}
+
+	security.DeleteBasicUser(username)
+	ctx.SetStatusCode(fasthttp.StatusOK)
+}

--- a/internal/transport/http/api/security/get_user_by_username.go
+++ b/internal/transport/http/api/security/get_user_by_username.go
@@ -1,0 +1,28 @@
+package http_security
+
+import (
+	"github.com/taymour/elysiandb/internal/security"
+	"github.com/valyala/fasthttp"
+)
+
+func GetUserByUsernameController(ctx *fasthttp.RequestCtx) {
+	ctx.Response.Header.Set("Content-Type", "application/json")
+	username := ctx.UserValue("user_name").(string)
+
+	if canManage, err := security.CurrentUserCanManageUser(ctx, username); err != nil || !canManage {
+		ctx.SetStatusCode(fasthttp.StatusForbidden)
+		return
+	}
+
+	user, err := security.GetBasicUserByUsername(username)
+	if err != nil {
+		ctx.SetStatusCode(fasthttp.StatusNotFound)
+		ctx.SetBodyString(`{"error":"` + err.Error() + `"}`)
+		return
+	}
+
+	responseBody := `{"username":"` + user["username"].(string) + `","role":"` + user["role"].(string) + `"}`
+
+	ctx.SetBodyString(responseBody)
+	ctx.SetStatusCode(fasthttp.StatusOK)
+}

--- a/internal/transport/http/api/security/get_users.go
+++ b/internal/transport/http/api/security/get_users.go
@@ -1,0 +1,36 @@
+package http_security
+
+import (
+	"github.com/taymour/elysiandb/internal/security"
+	"github.com/valyala/fasthttp"
+)
+
+func GetUsersController(ctx *fasthttp.RequestCtx) {
+	ctx.Response.Header.Set("Content-Type", "application/json")
+
+	if !security.CurrentUserIsAdmin(ctx) {
+		ctx.SetStatusCode(fasthttp.StatusForbidden)
+		ctx.SetBodyString(`{"error":"forbidden"}`)
+
+		return
+	}
+
+	users, err := security.ListBasicUsers()
+	if err != nil {
+		ctx.SetStatusCode(fasthttp.StatusInternalServerError)
+		ctx.SetBodyString(`{"error":"` + err.Error() + `"}`)
+		return
+	}
+
+	responseBody := `{"users":[`
+	for i, user := range users {
+		if i > 0 {
+			responseBody += ","
+		}
+		responseBody += `{"username":"` + user["username"].(string) + `","role":"` + user["role"].(string) + `"}`
+	}
+	responseBody += `]}`
+
+	ctx.SetBodyString(responseBody)
+	ctx.SetStatusCode(fasthttp.StatusOK)
+}

--- a/test/internal/routing_test/router_test.go
+++ b/test/internal/routing_test/router_test.go
@@ -122,6 +122,7 @@ func TestRegisterRoutes_NoOptional(t *testing.T) {
 		{"PUT", "/api/tx/t1/entity/x/1"},
 		{"DELETE", "/api/tx/t1/entity/x/1"},
 		{"POST", "/api/tx/t1/commit"},
+		{"GET", "/config"},
 	}
 
 	for _, c := range tests {

--- a/test/internal/transport_test/http_test/api_test/security_test/security_test.go
+++ b/test/internal/transport_test/http_test/api_test/security_test/security_test.go
@@ -1,0 +1,255 @@
+package http_security_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/taymour/elysiandb/internal/configuration"
+	"github.com/taymour/elysiandb/internal/globals"
+	"github.com/taymour/elysiandb/internal/security"
+	"github.com/taymour/elysiandb/internal/storage"
+	http_security "github.com/taymour/elysiandb/internal/transport/http/api/security"
+	"github.com/valyala/fasthttp"
+)
+
+func setup(t *testing.T) {
+	cfg := &configuration.Config{}
+	cfg.Store.Folder = t.TempDir()
+	cfg.Store.Shards = 4
+	cfg.Security.Authentication.Enabled = true
+	cfg.Security.Authentication.Mode = "user"
+	globals.SetConfig(cfg)
+
+	storage.LoadDB()
+	storage.LoadJsonDB()
+
+	_ = security.InitBasicUsersStorage()
+	_ = security.InitAdminUserIfNotExists()
+}
+
+func newCtx(method, uri, body string, session *security.Session) *fasthttp.RequestCtx {
+	req := fasthttp.AcquireRequest()
+	req.SetRequestURI(uri)
+	req.Header.SetMethod(method)
+	if body != "" {
+		req.SetBodyString(body)
+	}
+	if session != nil {
+		req.Header.SetCookie(security.SessionCookieName, session.ID)
+	}
+	ctx := &fasthttp.RequestCtx{}
+	ctx.Init(req, nil, nil)
+	return ctx
+}
+
+func login(t *testing.T, username string, role security.Role) *security.Session {
+	s, err := security.CreateSession(username, role, time.Minute)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return s
+}
+
+func TestGetUsersController_AdminOK(t *testing.T) {
+	setup(t)
+
+	_ = security.CreateBasicUser(&security.BasicUser{Username: "u1", Password: "p1", Role: security.RoleUser})
+
+	s := login(t, security.DefaultAdminUsername, security.RoleAdmin)
+	ctx := newCtx("GET", "/api/security/user", "", s)
+
+	http_security.GetUsersController(ctx)
+
+	if ctx.Response.StatusCode() != fasthttp.StatusOK {
+		t.Fatal("expected 200")
+	}
+}
+
+func TestGetUsersController_Forbidden(t *testing.T) {
+	setup(t)
+
+	s := login(t, "user", security.RoleUser)
+	ctx := newCtx("GET", "/api/security/user", "", s)
+
+	http_security.GetUsersController(ctx)
+
+	if ctx.Response.StatusCode() != fasthttp.StatusForbidden {
+		t.Fatal("expected 403")
+	}
+}
+
+func TestGetUserByUsernameController_AdminOK(t *testing.T) {
+	setup(t)
+
+	_ = security.CreateBasicUser(&security.BasicUser{Username: "bob", Password: "x", Role: security.RoleUser})
+
+	s := login(t, security.DefaultAdminUsername, security.RoleAdmin)
+	ctx := newCtx("GET", "/api/security/user/bob", "", s)
+	ctx.SetUserValue("user_name", "bob")
+
+	http_security.GetUserByUsernameController(ctx)
+
+	if ctx.Response.StatusCode() != fasthttp.StatusOK {
+		t.Fatal("expected 200")
+	}
+}
+
+func TestGetUserByUsernameController_ForbiddenSelf(t *testing.T) {
+	setup(t)
+
+	_ = security.CreateBasicUser(&security.BasicUser{Username: "bob", Password: "x", Role: security.RoleUser})
+
+	s := login(t, "bob", security.RoleUser)
+	ctx := newCtx("GET", "/api/security/user/bob", "", s)
+	ctx.SetUserValue("user_name", "bob")
+
+	http_security.GetUserByUsernameController(ctx)
+
+	if ctx.Response.StatusCode() != fasthttp.StatusForbidden {
+		t.Fatal("expected 403")
+	}
+}
+
+func TestCreateUserController_AdminOK(t *testing.T) {
+	setup(t)
+
+	s := login(t, security.DefaultAdminUsername, security.RoleAdmin)
+
+	body := `{"username":"alice","password":"pwd","role":"user"}`
+	ctx := newCtx("POST", "/api/security/user", body, s)
+
+	http_security.CreateUserController(ctx)
+
+	if ctx.Response.StatusCode() != fasthttp.StatusOK {
+		t.Fatal("expected 200")
+	}
+
+	if _, err := security.GetBasicUserByUsername("alice"); err != nil {
+		t.Fatal("user not created")
+	}
+}
+
+func TestCreateUserController_Forbidden(t *testing.T) {
+	setup(t)
+
+	s := login(t, "user", security.RoleUser)
+
+	body := `{"username":"alice","password":"pwd","role":"user"}`
+	ctx := newCtx("POST", "/api/security/user", body, s)
+
+	http_security.CreateUserController(ctx)
+
+	if ctx.Response.StatusCode() != fasthttp.StatusForbidden {
+		t.Fatal("expected 403")
+	}
+}
+
+func TestCreateUserController_InvalidJSON(t *testing.T) {
+	setup(t)
+
+	s := login(t, security.DefaultAdminUsername, security.RoleAdmin)
+
+	ctx := newCtx("POST", "/api/security/user", `{bad`, s)
+
+	http_security.CreateUserController(ctx)
+
+	if ctx.Response.StatusCode() != fasthttp.StatusBadRequest {
+		t.Fatal("expected 400")
+	}
+}
+
+func TestDeleteUserByUsernameController_OK(t *testing.T) {
+	setup(t)
+
+	_ = security.CreateBasicUser(&security.BasicUser{Username: "todelete", Password: "x", Role: security.RoleUser})
+
+	s := login(t, security.DefaultAdminUsername, security.RoleAdmin)
+	ctx := newCtx("DELETE", "/api/security/user/todelete", "", s)
+	ctx.SetUserValue("user_name", "todelete")
+
+	http_security.DeleteUserByUsernameController(ctx)
+
+	if ctx.Response.StatusCode() != fasthttp.StatusOK {
+		t.Fatal("expected 200")
+	}
+
+	if _, err := security.GetBasicUserByUsername("todelete"); err == nil {
+		t.Fatal("user should be deleted")
+	}
+}
+
+func TestDeleteUserByUsernameController_ForbiddenSelf(t *testing.T) {
+	setup(t)
+
+	s := login(t, "bob", security.RoleUser)
+	ctx := newCtx("DELETE", "/api/security/user/bob", "", s)
+	ctx.SetUserValue("user_name", "bob")
+
+	http_security.DeleteUserByUsernameController(ctx)
+
+	if ctx.Response.StatusCode() != fasthttp.StatusForbidden {
+		t.Fatal("expected 403")
+	}
+}
+
+func TestChangeUserPasswordController_OK(t *testing.T) {
+	setup(t)
+
+	_ = security.CreateBasicUser(&security.BasicUser{Username: "john", Password: "old", Role: security.RoleUser})
+
+	s := login(t, security.DefaultAdminUsername, security.RoleAdmin)
+	ctx := newCtx("PUT", "/api/security/user/john/password", `{"password":"new"}`, s)
+	ctx.SetUserValue("user_name", "john")
+
+	http_security.ChangeUserPasswordController(ctx)
+
+	if ctx.Response.StatusCode() != fasthttp.StatusOK {
+		t.Fatal("expected 200")
+	}
+
+	if _, ok := security.AuthenticateUser("john", "new"); !ok {
+		t.Fatal("password not changed")
+	}
+}
+
+func TestChangeUserPasswordController_InvalidJSON(t *testing.T) {
+	setup(t)
+
+	s := login(t, security.DefaultAdminUsername, security.RoleAdmin)
+	ctx := newCtx("PUT", "/api/security/user/john/password", `{bad`, s)
+	ctx.SetUserValue("user_name", "john")
+
+	http_security.ChangeUserPasswordController(ctx)
+
+	if ctx.Response.StatusCode() != fasthttp.StatusBadRequest {
+		t.Fatal("expected 400")
+	}
+}
+
+func TestChangeUserPasswordController_ForbiddenSelf(t *testing.T) {
+	setup(t)
+
+	s := login(t, "bob", security.RoleUser)
+	ctx := newCtx("PUT", "/api/security/user/bob/password", `{"password":"x"}`, s)
+	ctx.SetUserValue("user_name", "bob")
+
+	http_security.ChangeUserPasswordController(ctx)
+
+	if ctx.Response.StatusCode() != fasthttp.StatusForbidden {
+		t.Fatal("expected 403")
+	}
+}
+
+func TestChangeUserPasswordController_UserNotFound(t *testing.T) {
+	setup(t)
+
+	s := login(t, security.DefaultAdminUsername, security.RoleAdmin)
+	ctx := newCtx("PUT", "/api/security/user/ghost/password", `{"password":"x"}`, s)
+	ctx.SetUserValue("user_name", "ghost")
+
+	http_security.ChangeUserPasswordController(ctx)
+
+	if ctx.Response.StatusCode() != fasthttp.StatusNotFound {
+		t.Fatal("expected 404")
+	}
+}


### PR DESCRIPTION
This PR introduces full user management support in ElysianDB, covering both backend APIs and the Admin UI.

**Backend**

* Added secured REST endpoints for user CRUD operations (`list`, `get`, `create`, `delete`, `change password`)
* Endpoints are available only when authentication is enabled in `user` mode
* Access control enforced via sessions and roles (admin vs user)
* Comprehensive unit tests added for security logic and controllers

**Admin UI**

* New Users page integrated into the Admin UI
* User listing with search, role display, and actions
* Modal-based user creation and password change
* Deletion support with proper permission handling
* Consistent glass-style UI aligned with existing entity views

This completes the user management workflow required by the Admin UI and lays the foundation for role-based administration in ElysianDB.

Closes https://github.com/elysiandb/elysiandb/issues/134